### PR TITLE
Remove promiscuous filter finding

### DIFF
--- a/include/filters/filter_chain.h
+++ b/include/filters/filter_chain.h
@@ -198,20 +198,10 @@ public:
         }
 
 
-	//CHeck for backwards compatible declarations
 	if (std::string(config[i]["type"]).find("/") == std::string::npos)
 	  {
-	    ROS_WARN("Deprecation Warning: No '/' detected in FilterType, Please update to 1.2 plugin syntax. ");
-	    std::vector<std::string> libs = loader_.getDeclaredClasses();
-	    for (std::vector<std::string>::iterator it = libs.begin(); it != libs.end(); ++it)
-	      {
-		size_t position =  it->find(std::string(config[i]["type"]));
-		if (position != std::string::npos)
-		  {
-		    ROS_WARN("Replaced %s with %s", std::string(config[i]["type"]).c_str(), it->c_str());
-		    config[i]["type"] = *it;
-		  }
-	      }
+	    ROS_ERROR("Bad filter type %s. Filter type must be of form <package_name>/<filter_name>", config[i]["type"]);
+        return false;
 	  }
 	//Make sure the filter chain has a valid type
 	std::vector<std::string> libs = loader_.getDeclaredClasses();

--- a/test/test_chain.yaml
+++ b/test/test_chain.yaml
@@ -1,113 +1,113 @@
 MultiChannelMedianFilterDouble5:
   - name: median_test
-    type: MultiChannelMedianFilterDouble
+    type: filters/MultiChannelMedianFilterDouble
     params: {number_of_observations: 5}
 MultiChannelMedianFilterFloat5:
   - name: median_test
-    type: MultiChannelMedianFilterFloat
+    type: filters/MultiChannelMedianFilterFloat
     params: {number_of_observations: 5}
 
 MultiChannelMeanFilterDouble5:
   - name: mean_test
-    type: MultiChannelMeanFilterDouble
+    type: filters/MultiChannelMeanFilterDouble
     params: {number_of_observations: 5}
 
 TwoFilters:
   - name: median_test_unique
-    type: MultiChannelMedianFilterDouble
+    type: filters/MultiChannelMedianFilterDouble
     params: {number_of_observations: 5}
   - name: median_test2
-    type: MultiChannelMedianFilterDouble
+    type: filters/MultiChannelMedianFilterDouble
     params: {number_of_observations: 5}
 
 TransferFunction:
   - name: transfer_function
-    type: MultiChannelTransferFunctionFilterDouble
+    type: filters/MultiChannelTransferFunctionFilterDouble
     params:
       a: [1.0, -1.760041880343169, 1.182893262037831]
       b: [0.018098933007514, 0.054296799022543, 0.054296799022543, 0.018098933007514]
     
 MeanFilterFloat5:
   - name: mean_test
-    type: MeanFilterFloat
+    type: filters/MeanFilterFloat
     params: {number_of_observations: 5}
 
 OneIncrements:
   - name: increment1
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
 
 TwoIncrements:
   - name: increment1
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment2
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
 
 ThreeIncrements:
   - name: increment1
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment2
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment3
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
 
 TenIncrements:
   - name: increment1
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment2
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment3
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment4
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment5
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment6
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment7
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment8
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment9
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment10
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
 
 OneMultiChannelIncrements:
   - name: increment1
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
 
 TwoMultiChannelIncrements:
   - name: increment1
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment2
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
 
 ThreeMultiChannelIncrements:
   - name: increment1
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment2
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
   - name: increment3
-    type: IncrementFilterInt
+    type: filters/IncrementFilterInt
 
 TenMultiChannelIncrements:
   - name: increment1
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment2
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment3
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment4
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment5
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment6
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment7
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment8
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment9
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt
   - name: increment10
-    type: MultiChannelIncrementFilterInt
+    type: filters/MultiChannelIncrementFilterInt


### PR DESCRIPTION
When specifying filters, you must now include the package name and exact filter name. Previously a workaround would search packages for any filter with the specified string in the filter name. This has been deprecated for a while, and here we're removing it.

See discussion in https://github.com/ros/filters/issues/14

Note that even the tests in this package and in laser_filters didn't specify the package name, so I've updated the tests in this PR and in https://github.com/ros-perception/laser_filters/pull/51

@tfoote @v4hn