### PR TITLE
Fix warning about string type

### DIFF
--- a/include/filters/filter_chain.h
+++ b/include/filters/filter_chain.h
@@ -200,7 +200,7 @@ public:
 
 	if (std::string(config[i]["type"]).find("/") == std::string::npos)
 	  {
-	    ROS_ERROR("Bad filter type %s. Filter type must be of form <package_name>/<filter_name>", config[i]["type"]);
+	    ROS_ERROR("Bad filter type %s. Filter type must be of form <package_name>/<filter_name>", std::string(config[i]["type"]).c_str());
         return false;
 	  }
 	//Make sure the filter chain has a valid type


### PR DESCRIPTION
As pointed out by @ipa-mdl , the xmlrpc type getting passed directly to ROS error results in a warning. This PR fixes the warning by casting to a string, then to a C string.

(Output copied from comment on https://github.com/ros/filters/pull/15/files/95e5475b6dd54dfdc4c1902c589dd36ffe5d326f ):
```
/home/mathias/build/lunar/src/ros_canopen/canopen_motor_node/src/handle_layer.cpp:174:81:   required from here
/opt/ros/lunar/include/ros/console.h:346:26: warning: format ‘%s’ expects argument of type ‘char*’, but argument 8 has type ‘XmlRpc::XmlRpcValue*’ [-Wformat=]
     ::ros::console::print(filter, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, __FILE__, __LINE__, __ROSCONSOLE_FUNCTION__, __VA_ARGS__)
     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/lunar/include/ros/console.h:349:5: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER’
     ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER(0, __VA_ARGS__)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/lunar/include/ros/console.h:379:7: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION’
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/lunar/include/ros/console.h:561:35: note: in expansion of macro ‘ROS_LOG_COND’
 #define ROS_LOG(level, name, ...) ROS_LOG_COND(true, level, name, __VA_ARGS__)
                                   ^~~~~~~~~~~~
/opt/ros/lunar/include/rosconsole/macros_generated.h:214:24: note: in expansion of macro ‘ROS_LOG’
 #define ROS_ERROR(...) ROS_LOG(::ros::console::levels::Error, ROSCONSOLE_DEFAULT_NAME, __VA_ARGS__)
                        ^~~~~~~
/opt/ros/lunar/include/filters/filter_chain.h:203:6: note: in expansion of macro ‘ROS_ERROR’
      ROS_ERROR("Bad filter type %s. Filter type must be of form <package_name>/<filter_name>", config[i]["type"]);
```