### PR TITLE
Make filters build for ros2 (on windows 10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,75 +1,53 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
+
 project(filters)
 
-##############################################################################
-# Find dependencies
-##############################################################################
+find_package(ament_cmake REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS pluginlib roslib roscpp rosconsole)
-find_package(Boost COMPONENTS system filesystem thread REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(xmlrpcpp REQUIRED)
 
 include_directories(
     include
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-)
-
-##############################################################################
-# Define package
-##############################################################################
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES mean params increment median transfer_function
-  CATKIN_DEPENDS roslib roscpp rosconsole pluginlib
+    ${rclcpp_INCLUDE_DIRS}
+    ${rcutils_INCLUDE_DIRS}
+    ${class_loader_INCLUDE_DIRS}
+    ${pluginlib_INCLUDE_DIRS}
+    ${xmlrpcpp_INCLUDE_DIRS}
+    $ENV{BOOST_ROOT}
 )
 
 ##############################################################################
 # Build
 ##############################################################################
 
+add_definitions(-DROS2)
+
 # Plugins
 add_library(mean src/mean.cpp)
-target_link_libraries(mean ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(mean ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(params src/test_params.cpp)
-target_link_libraries(params ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(params ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(increment src/increment.cpp)
-target_link_libraries(increment ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(increment ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(median src/median.cpp)
-target_link_libraries(median ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(median ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(transfer_function src/transfer_function.cpp)
-target_link_libraries(transfer_function ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(transfer_function ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 
-if(CATKIN_ENABLE_TESTING)
-  find_package(rostest)
-  # Test median filter
-  add_executable(median_test EXCLUDE_FROM_ALL test/test_median.cpp )
-  target_link_libraries(median_test median ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES}) 
-  add_rostest(test/test_median.launch)
 
-  # Test transfer function filter
-  add_executable(transfer_function_test EXCLUDE_FROM_ALL test/test_transfer_function.cpp)
-  target_link_libraries(transfer_function_test transfer_function ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
-  add_rostest(test/test_transfer_function.launch)
-
-  # Test mean filter
-  add_executable(mean_test EXCLUDE_FROM_ALL test/test_mean.cpp)
-  target_link_libraries(mean_test mean ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
-  add_rostest(test/test_mean.launch)
-
-  # Test params filter
-  add_executable(params_test EXCLUDE_FROM_ALL test/test_params.cpp)
-  target_link_libraries(params_test params ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
-  add_rostest(test/test_params.launch)
-
-  # Test plugin loading into filter chain
-  add_executable(chain_test EXCLUDE_FROM_ALL test/test_chain.cpp)
-  target_link_libraries(chain_test increment ${Boost_libraries} ${catkin_LIBRARIES} ${GTEST_LIBRARIES}) # Needed for OSX
-  add_rostest(test/test_chain.launch)
-
-  # Test realtime safe buffer class
-  catkin_add_gtest(realtime_buffer_test EXCLUDE_FROM_ALL test/test_realtime_circular_buffer.cpp)
-endif()
+pluginlib_export_plugin_description_file(filters default_plugins.xml)
+ament_export_include_directories(include)
+ament_export_libraries(
+  mean 
+  params 
+  increment
+  median
+  transfer_function
+)
+ament_package()
 
 ##############################################################################
 # Install
@@ -77,22 +55,16 @@ endif()
 
 # Install libraries
 install(TARGETS mean params increment median transfer_function
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 # Install headers
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  DESTINATION include/${PROJECT_NAME}/)
 
 # Install plugins xml file
-install(FILES default_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
-
-if(CATKIN_ENABLE_TESTING)
-  if(TARGET tests)
-  add_dependencies(tests median_test transfer_function_test mean_test params_test chain_test)
-  endif()
-endif()
+#install(FILES default_plugins.xml
+#  DESTINATION share
+#)

--- a/include/filters/mean.h
+++ b/include/filters/mean.h
@@ -37,7 +37,6 @@
 #include <boost/scoped_ptr.hpp>
 
 #include "filters/filter_base.h"
-#include "ros/assert.h"
 
 #include "filters/realtime_circular_buffer.h"
 

--- a/include/filters/param_test.h
+++ b/include/filters/param_test.h
@@ -34,10 +34,7 @@
 #include <cstring>
 #include <stdio.h>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "filters/filter_base.h"
-#include "ros/assert.h"
 
 
 namespace filters

--- a/package.xml
+++ b/package.xml
@@ -1,32 +1,27 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>filters</name>
-  <version>1.8.1</version>
+  <version>1.8.2</version>
   <description>
-    This library provides a standardized interface for processing data as a sequence 
+    This library provides a standardized interface for processing data as a sequence
     of filters.  This package contains a base class upon which to build specific implementations
-    as well as an interface which dynamically loads filters based on runtime parameters.  
+    as well as an interface which dynamically loads filters based on runtime parameters.
   </description>
-
   <maintainer email="tfoote@willowgarage.com">Tully Foote</maintainer>
   <license>BSD</license>
   <url>http://ros.org/wiki/filters</url>
 
-  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>roslib</build_depend>
-  <build_depend>rosconsole</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>rostest</build_depend>
+  <depend>rclcpp</depend>
+  <depend>pluginlib</depend>
+  <depend>rcutils</depend>
+  <depend>xmlrpcpp</depend>
 
-  <run_depend>roslib</run_depend>
-  <run_depend>rosconsole</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>pluginlib</run_depend>
-
+  <exec_depend>ament_cmake</exec_depend>
 
   <export>
-    <filters plugin="${prefix}/default_plugins.xml" />
+    <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/src/increment.cpp
+++ b/src/increment.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/increment.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 
 

--- a/src/mean.cpp
+++ b/src/mean.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/mean.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 
 

--- a/src/median.cpp
+++ b/src/median.cpp
@@ -29,7 +29,8 @@
 
 
 #include "filters/median.h"
-#include <pluginlib/class_list_macros.h>
+#include "pluginlib/class_list_macros.hpp"
+
 
 
 //Double precision

--- a/src/test_params.cpp
+++ b/src/test_params.cpp
@@ -29,7 +29,7 @@
 
 
 #include "filters/param_test.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(filters::ParamTest<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::ParamTest<int>, filters::FilterBase<int>)

--- a/src/transfer_function.cpp
+++ b/src/transfer_function.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/transfer_function.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(filters::SingleChannelTransferFunctionFilter<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelTransferFunctionFilter<double>, filters::MultiChannelFilterBase<double>)


### PR DESCRIPTION
Should go to a ROS2 branch, but I'm not sure how to create a PR for that :)

Working towards enabling laser_filters in ROS2.  This provides ability to build and updates for ROS2 constructs (like Node vs NodeHandle).

Remaining work includes enabling input parameters that define the actual filter loading (this is commented out currently).