### PR TITLE
Make filters build for ros2 (on windows 10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(xmlrpcpp REQUIRED)
+
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost REQUIRED)
 
 include_directories(
     include
@@ -15,8 +17,7 @@ include_directories(
     ${rcutils_INCLUDE_DIRS}
     ${class_loader_INCLUDE_DIRS}
     ${pluginlib_INCLUDE_DIRS}
-    ${xmlrpcpp_INCLUDE_DIRS}
-    $ENV{BOOST_ROOT}
+    ${Boost_INCLUDE_DIRS}
 )
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,75 +1,53 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
+
 project(filters)
 
-##############################################################################
-# Find dependencies
-##############################################################################
+find_package(ament_cmake REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS pluginlib roslib roscpp rosconsole)
-find_package(Boost COMPONENTS system filesystem thread REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(xmlrpcpp REQUIRED)
 
 include_directories(
     include
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-)
-
-##############################################################################
-# Define package
-##############################################################################
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES mean params increment median transfer_function
-  CATKIN_DEPENDS roslib roscpp rosconsole pluginlib
+    ${rclcpp_INCLUDE_DIRS}
+    ${rcutils_INCLUDE_DIRS}
+    ${class_loader_INCLUDE_DIRS}
+    ${pluginlib_INCLUDE_DIRS}
+    ${xmlrpcpp_INCLUDE_DIRS}
+    $ENV{BOOST_ROOT}
 )
 
 ##############################################################################
 # Build
 ##############################################################################
 
+add_definitions(-DROS2)
+
 # Plugins
 add_library(mean src/mean.cpp)
-target_link_libraries(mean ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(mean ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(params src/test_params.cpp)
-target_link_libraries(params ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(params ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(increment src/increment.cpp)
-target_link_libraries(increment ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(increment ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(median src/median.cpp)
-target_link_libraries(median ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(median ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 add_library(transfer_function src/transfer_function.cpp)
-target_link_libraries(transfer_function ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(transfer_function ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})
 
-if(CATKIN_ENABLE_TESTING)
-  find_package(rostest)
-  # Test median filter
-  add_executable(median_test EXCLUDE_FROM_ALL test/test_median.cpp )
-  target_link_libraries(median_test median ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES}) 
-  add_rostest(test/test_median.launch)
 
-  # Test transfer function filter
-  add_executable(transfer_function_test EXCLUDE_FROM_ALL test/test_transfer_function.cpp)
-  target_link_libraries(transfer_function_test transfer_function ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
-  add_rostest(test/test_transfer_function.launch)
-
-  # Test mean filter
-  add_executable(mean_test EXCLUDE_FROM_ALL test/test_mean.cpp)
-  target_link_libraries(mean_test mean ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
-  add_rostest(test/test_mean.launch)
-
-  # Test params filter
-  add_executable(params_test EXCLUDE_FROM_ALL test/test_params.cpp)
-  target_link_libraries(params_test params ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
-  add_rostest(test/test_params.launch)
-
-  # Test plugin loading into filter chain
-  add_executable(chain_test EXCLUDE_FROM_ALL test/test_chain.cpp)
-  target_link_libraries(chain_test increment ${Boost_libraries} ${catkin_LIBRARIES} ${GTEST_LIBRARIES}) # Needed for OSX
-  add_rostest(test/test_chain.launch)
-
-  # Test realtime safe buffer class
-  catkin_add_gtest(realtime_buffer_test EXCLUDE_FROM_ALL test/test_realtime_circular_buffer.cpp)
-endif()
+pluginlib_export_plugin_description_file(filters default_plugins.xml)
+ament_export_include_directories(include)
+ament_export_libraries(
+  mean 
+  params 
+  increment
+  median
+  transfer_function
+)
+ament_package()
 
 ##############################################################################
 # Install
@@ -77,22 +55,16 @@ endif()
 
 # Install libraries
 install(TARGETS mean params increment median transfer_function
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 # Install headers
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  DESTINATION include/${PROJECT_NAME}/)
 
 # Install plugins xml file
-install(FILES default_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
-
-if(CATKIN_ENABLE_TESTING)
-  if(TARGET tests)
-  add_dependencies(tests median_test transfer_function_test mean_test params_test chain_test)
-  endif()
-endif()
+#install(FILES default_plugins.xml
+#  DESTINATION share
+#)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,6 @@ include_directories(
 # Build
 ##############################################################################
 
-add_definitions(-DROS2)
-
 # Plugins
 add_library(mean src/mean.cpp)
 target_link_libraries(mean ${rclcpp_LIBRARIES} ${rcutils_LIBRARIES})

--- a/include/filters/filter_base.h
+++ b/include/filters/filter_base.h
@@ -30,29 +30,35 @@
 #ifndef FILTERS_FILTER_BASE_H_
 #define FILTERS_FILTER_BASE_H_
 
-#include <typeinfo>
-#include "ros/assert.h"
-#include "ros/console.h"
-#include "ros/ros.h"
+#include "rclcpp/rclcpp.hpp"
 
-#include "boost/scoped_ptr.hpp"
-#include <boost/algorithm/string.hpp>
+// TODO: fix this so that it has actual implementations
+#ifndef ROS_ERROR
+#define ROS_ERROR(...)
+#endif // !ROS_ERROR
+#ifndef ROS_DEBUG
+#define ROS_DEBUG(...)
+#endif // !ROS_DEBUG
+#ifndef ROS_WARN
+#define ROS_WARN(...)
+#endif // !ROS_WARN
 
 namespace filters
 {
 
-typedef std::map<std::string, XmlRpc::XmlRpcValue> string_map_t;
+typedef std::map<std::string, rclcpp::parameter::ParameterVariant> string_map_t;
+
 
 /** \brief A Base filter class to provide a standard interface for all filters
  *
  */
 template<typename T>
-class FilterBase
+class FilterBase : rclcpp::Node
 {
 public:
   /** \brief Default constructor used by Filter Factories
    */
-  FilterBase():configured_(false){};
+  FilterBase() : rclcpp::Node("filterbase"), configured_(false){};
 
   /** \brief Virtual Destructor
    */
@@ -60,24 +66,24 @@ public:
 
   /** \brief Configure the filter from the parameter server 
    * \param The parameter from which to read the configuration
-   * \param node_handle The optional node handle, useful if operating in a different namespace.
+   * \param node_handle The optional node, useful?
    */
-  bool configure(const std::string& param_name, ros::NodeHandle node_handle = ros::NodeHandle())
+  bool configure(const std::string& param_name, rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("filter_base"))
   {
-    XmlRpc::XmlRpcValue config;
-    if (!node_handle.getParam(param_name, config))
+    rclcpp::parameter::ParameterVariant config;
+    if (!node->get_parameter(param_name, config))
     {
       ROS_ERROR("Could not find parameter %s on the server, are you sure that it was pushed up correctly?", param_name.c_str());
       return false;
     }
-    return configure(config);
-    
+    return configure(config, node);
   }
 
-  /** \brief The public method to configure a filter from XML 
-   * \param config The XmlRpcValue from which the filter should be initialized
+  /** \brief The public method to configure a filter from parameters
+   * \param config The ParameterVariant from which the filter should be initialized (useful?)
+   * \param node The node from which the filter should be initialized (useful?)
    */
-  bool configure(XmlRpc::XmlRpcValue& config)
+  bool configure(rclcpp::parameter::ParameterVariant& config, rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("filter_base"))
   {
     if (configured_)
     {
@@ -86,7 +92,7 @@ public:
     configured_ = false;
     bool retval = true;
 
-    retval = retval && loadConfiguration(config);
+    retval = retval && loadConfiguration(config, node);
     retval = retval && configure();
     configured_ = retval;
     return retval;
@@ -120,18 +126,10 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(const std::string& name, std::string& value)
   {
-    string_map_t::iterator it = params_.find(name);
-    if (it == params_.end())
-    {
+    rclcpp::parameter::ParameterVariant valueV;
+    if (!getParam(name, valueV))
       return false;
-    }
-
-    if(it->second.getType() != XmlRpc::XmlRpcValue::TypeString)
-    {
-      return false;
-    }
-
-    value = std::string(it->second);
+    value = valueV.as_string();
     return true;
   }
 
@@ -141,18 +139,10 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(const std::string& name, bool& value)
   {
-    string_map_t::iterator it = params_.find(name);
-    if (it == params_.end())
-    {
+    rclcpp::parameter::ParameterVariant valueV;
+    if (!getParam(name, valueV))
       return false;
-    }
-
-    if(it->second.getType() != XmlRpc::XmlRpcValue::TypeBoolean)
-    {
-      return false;
-    }
-
-    value = (bool)(it->second);
+    value = valueV.as_bool();
     return true;
   }
 
@@ -162,18 +152,10 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(const std::string&name, double& value)
   {
-    string_map_t::iterator it = params_.find(name);
-    if (it == params_.end())
-    {
+    rclcpp::parameter::ParameterVariant valueV;
+    if (!getParam(name, valueV))
       return false;
-    }
-
-    if(it->second.getType() != XmlRpc::XmlRpcValue::TypeDouble && it->second.getType() != XmlRpc::XmlRpcValue::TypeInt)
-    {
-      return false;
-    }
-
-    value = it->second.getType() == XmlRpc::XmlRpcValue::TypeInt ? (int)(it->second) : (double)(it->second);
+    value = valueV.as_double();
     return true;
   }
 
@@ -183,18 +165,10 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(const std::string&name, int& value)
   {
-    string_map_t::iterator it = params_.find(name);
-    if (it == params_.end())
-    {
+    rclcpp::parameter::ParameterVariant valueV;
+    if (!getParam(name, valueV))
       return false;
-    }
-
-    if(it->second.getType() != XmlRpc::XmlRpcValue::TypeInt)
-    {
-      return false;
-    }
-
-    value = it->second;
+    value = valueV.as_int();
     return true;
   }
 
@@ -204,12 +178,10 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(const std::string&name, unsigned  int& value)
   {
-    int signed_value;
-    if (!getParam(name, signed_value))
+    rclcpp::parameter::ParameterVariant valueV;
+    if (!getParam(name, valueV))
       return false;
-    if (signed_value < 0)
-      return false;
-    value = signed_value;
+    value = (unsigned int)valueV.as_int();
     return true;
   };
 
@@ -219,32 +191,8 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(const std::string&name, std::vector<double>& value)
   {
-    string_map_t::iterator it = params_.find(name);
-    if (it == params_.end())
-    {
-      return false;
-    }
-
-    value.clear();
-
-    if(it->second.getType() != XmlRpc::XmlRpcValue::TypeArray)
-    {
-      return false;
-    }
-
-    XmlRpc::XmlRpcValue double_array = it->second;
-
-    for (int i = 0; i < double_array.size(); ++i){
-      if(double_array[i].getType() != XmlRpc::XmlRpcValue::TypeDouble && double_array[i].getType() != XmlRpc::XmlRpcValue::TypeInt)
-      {
-        return false;
-      }
-
-      double double_value = double_array[i].getType() == XmlRpc::XmlRpcValue::TypeInt ? (int)(double_array[i]) : (double)(double_array[i]);
-      value.push_back(double_value);
-    }
-    
-    return true;
+    // TODO: handle arrays?
+    return false;
   }
 
   /** \brief Get a filter parameter as a std::vector<string>
@@ -253,39 +201,19 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(const std::string&name, std::vector<std::string>& value)
   {
-    string_map_t::iterator it = params_.find(name);
-    if (it == params_.end())
-    {
-      return false;
-    }
-
-    value.clear();
-
-    if(it->second.getType() != XmlRpc::XmlRpcValue::TypeArray)
-    {
-      return false;
-    }
-
-    XmlRpc::XmlRpcValue string_array = it->second;
-    
-    for (unsigned int i = 0; i < string_array.size(); ++i){
-      if(string_array[i].getType() != XmlRpc::XmlRpcValue::TypeString)
-      {
-        return false;
-      }
-
-      value.push_back(string_array[i]);
-    }
-
-    return true;
+    // TODO: handle arrays?
+    return false;
   }
 
-  /** \brief Get a filter parameter as a XmlRpcValue
+  /** \brief Get a filter parameter as a string
    * \param name The name of the parameter
-   * \param value The XmlRpcValue to set with the value
+   * \param value The string to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string& name, XmlRpc::XmlRpcValue& value)
+  bool getParam(const std::string& name, rclcpp::parameter::ParameterVariant& value)
   {
+    // TODO: defer to underlying node impl or params_?
+    //return get_parameter(name, value);
+
     string_map_t::iterator it = params_.find(name);
     if (it == params_.end())
     {
@@ -294,8 +222,9 @@ protected:
 
     value = it->second;
     return true;
+
   }
-  
+
   ///The name of the filter
   std::string filter_name_;
   ///The type of the filter (Used by FilterChain for Factory construction)
@@ -303,30 +232,30 @@ protected:
   /// Whether the filter has been configured.  
   bool configured_;
 
-  ///Storage of the parsed xml parameters
   string_map_t params_;
 
 private:
   /**\brief Set the name and type of the filter from the parameter server
    * \param param_name The parameter from which to read
    */
-  bool setNameAndType(XmlRpc::XmlRpcValue& config)
+  bool setNameAndType(rclcpp::Node::SharedPtr& node)
   {
-    if(!config.hasMember("name"))
+    rclcpp::parameter::ParameterVariant value;
+    if (!node->get_parameter("name", value))
     {
       ROS_ERROR("Filter didn't have name defined, other strings are not allowed");
       return false;
     }
 
-    std::string name = config["name"];
+    std::string name = value.as_string();
 
-    if(!config.hasMember("type"))
+    if (!node->get_parameter("type", value))
     {
       ROS_ERROR("Filter %s didn't have type defined, other strings are not allowed", name.c_str());
       return false;
     }
 
-    std::string type = config["type"];
+    std::string type = value.as_string();
 
     filter_name_ = name;
     filter_type_ = type;
@@ -335,42 +264,26 @@ private:
   }
 
 protected:
-  bool loadConfiguration(XmlRpc::XmlRpcValue& config)
+  bool loadConfiguration(rclcpp::parameter::ParameterVariant& config, rclcpp::Node::SharedPtr& node)
   {
-    if(config.getType() != XmlRpc::XmlRpcValue::TypeStruct)
-    {
-      ROS_ERROR("A filter configuration must be a map with fields name, type, and params");
-      return false;
-    } 
-
-    if (!setNameAndType(config))
+    if (!setNameAndType(node))
     {
       return false;
     }
+
+    // TODO: defer to underlying node impl or params_?
 
     //check to see if we have parameters in our list
-    if(config.hasMember("params"))
+    for (auto param : node->list_parameters({}, 0))
     {
-      //get the params map
-      XmlRpc::XmlRpcValue params = config["params"];
-
-      if(params.getType() != XmlRpc::XmlRpcValue::TypeStruct)
-      {
-        ROS_ERROR("params must be a map");
-        return false;
-      }
-      else{
-        //Load params into map
-        for(XmlRpc::XmlRpcValue::iterator it = params.begin(); it != params.end(); ++it)
-        {
-          ROS_DEBUG("Loading param %s\n", it->first.c_str());
-          params_[it->first] = it->second;
-        } 
-      }
+      auto value = node->get_parameter(param);
+      params_[param->first] = value;
     }
 
-    return true;    
+    return true;
   }
+
+
 };
 
 
@@ -383,28 +296,27 @@ public:
   /** \brief Configure the filter from the parameter server 
    * \param number_of_channels How many parallel channels the filter will process
    * \param The parameter from which to read the configuration
-   * \param node_handle The optional node handle, useful if operating in a different namespace.
+   * \param node The optional node, useful?
    */
-  bool configure(unsigned int number_of_channels, const std::string& param_name, ros::NodeHandle node_handle = ros::NodeHandle())
+  bool configure(unsigned int number_of_channels, const std::string& param_name, rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("multi_filter_base"))
   {
-    XmlRpc::XmlRpcValue config;
-    if (!node_handle.getParam(param_name, config))
+    rclcpp::parameter::ParameterVariant config;
+    if (!node->get_parameter(param_name, config))
     {
       ROS_ERROR("Could not find parameter %s on the server, are you sure that it was pushed up correctly?", param_name.c_str());
       return false;
     }
-    return configure(number_of_channels, config);
-    
+    configure(number_of_channels, config, node);
   }
 
-
-  /** \brief The public method to configure a filter from XML 
+  /** \brief The public method to configure a filter from ParameterVariant
    * \param number_of_channels How many parallel channels the filter will process
-   * \param config The XmlRpcValue to load the configuration from 
+   * \param config The parameter from which to read the configuration
+   * \param node The optional node, useful?
    */
-  bool configure(unsigned int number_of_channels, XmlRpc::XmlRpcValue& config)
+  bool configure(unsigned int number_of_channels, rclcpp::parameter::ParameterVariant& config, rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("multi_filter_base"))
   {
-    ROS_DEBUG("FilterBase being configured with XmlRpc xml: %s type: %d", config.toXml().c_str(), config.getType());
+    ROS_DEBUG("FilterBase being configured with parameter: %s type: %d", config.toXml().c_str(), config.get_type());
     if (configured_)
     {
       ROS_WARN("Filter %s of type %s already being reconfigured", filter_name_.c_str(), filter_type_.c_str());
@@ -414,7 +326,7 @@ public:
     ROS_DEBUG("MultiChannelFilterBase configured with %d channels", number_of_channels_);
     bool retval = true;
 
-    retval = retval && FilterBase<T>::loadConfiguration(config);
+    retval = retval && FilterBase<T>::loadConfiguration(node);
     retval = retval && configure();
     configured_ = retval;
     return retval;
@@ -422,7 +334,7 @@ public:
 
 
   /** \brief A method to hide the base class method and warn if improperly called */
-  bool configure(XmlRpc::XmlRpcValue& config)
+  bool configure(rclcpp::parameter::ParameterVariant& config, rclcpp::Node::SharedPtr& node = rclcpp::Node::make_shared("multi_filter_base"))
   {
     ROS_ERROR("MultiChannelFilterBase configure should be called with a number of channels argument, assuming 1");
     return configure(1, config);

--- a/include/filters/mean.h
+++ b/include/filters/mean.h
@@ -37,7 +37,6 @@
 #include <boost/scoped_ptr.hpp>
 
 #include "filters/filter_base.h"
-#include "ros/assert.h"
 
 #include "filters/realtime_circular_buffer.h"
 

--- a/include/filters/param_test.h
+++ b/include/filters/param_test.h
@@ -34,10 +34,7 @@
 #include <cstring>
 #include <stdio.h>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "filters/filter_base.h"
-#include "ros/assert.h"
 
 
 namespace filters

--- a/package.xml
+++ b/package.xml
@@ -1,32 +1,27 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>filters</name>
-  <version>1.8.1</version>
+  <version>1.8.2</version>
   <description>
-    This library provides a standardized interface for processing data as a sequence 
+    This library provides a standardized interface for processing data as a sequence
     of filters.  This package contains a base class upon which to build specific implementations
-    as well as an interface which dynamically loads filters based on runtime parameters.  
+    as well as an interface which dynamically loads filters based on runtime parameters.
   </description>
-
   <maintainer email="tfoote@willowgarage.com">Tully Foote</maintainer>
   <license>BSD</license>
   <url>http://ros.org/wiki/filters</url>
 
-  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>roslib</build_depend>
-  <build_depend>rosconsole</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>rostest</build_depend>
+  <depend>rclcpp</depend>
+  <depend>pluginlib</depend>
+  <depend>rcutils</depend>
+  <depend>xmlrpcpp</depend>
 
-  <run_depend>roslib</run_depend>
-  <run_depend>rosconsole</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>pluginlib</run_depend>
-
+  <exec_depend>ament_cmake</exec_depend>
 
   <export>
-    <filters plugin="${prefix}/default_plugins.xml" />
+    <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
   <depend>rclcpp</depend>
   <depend>pluginlib</depend>
   <depend>rcutils</depend>
-  <depend>xmlrpcpp</depend>
 
   <exec_depend>ament_cmake</exec_depend>
 

--- a/src/increment.cpp
+++ b/src/increment.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/increment.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 
 

--- a/src/mean.cpp
+++ b/src/mean.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/mean.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 
 

--- a/src/median.cpp
+++ b/src/median.cpp
@@ -29,7 +29,8 @@
 
 
 #include "filters/median.h"
-#include <pluginlib/class_list_macros.h>
+#include "pluginlib/class_list_macros.hpp"
+
 
 
 //Double precision

--- a/src/test_params.cpp
+++ b/src/test_params.cpp
@@ -29,7 +29,7 @@
 
 
 #include "filters/param_test.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(filters::ParamTest<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::ParamTest<int>, filters::FilterBase<int>)

--- a/src/transfer_function.cpp
+++ b/src/transfer_function.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/transfer_function.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(filters::SingleChannelTransferFunctionFilter<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelTransferFunctionFilter<double>, filters::MultiChannelFilterBase<double>)


### PR DESCRIPTION
Should go to a ROS2 branch, but I'm not sure how to create a PR for that :)

Working towards enabling laser_filters in ROS2. This provides ability to build and updates for ROS2 constructs (like Node vs NodeHandle).

Remaining work includes enabling input parameters that define the actual filter loading (this is commented out currently).