### PR TITLE
[Windows][lunar] Fix run_tests build breaks on Windows\MSVC

### DIFF
--- a/test/test_mean.cpp
+++ b/test/test_mean.cpp
@@ -28,17 +28,25 @@
  */
 
 #include <gtest/gtest.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#else
+#include <windows.h>
+#endif
 #include "filters/mean.h"
 
 using namespace filters ;
 
 void seed_rand()
 {
+#ifndef _WIN32
   //Seed random number generator with current microseond count
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
+#else
+  srand(GetTickCount());
+#endif
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)

--- a/test/test_mean.cpp
+++ b/test/test_mean.cpp
@@ -28,25 +28,15 @@
  */
 
 #include <gtest/gtest.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#else
-#include <windows.h>
-#endif
+#include <ctime>
+#include <cstdlib>
 #include "filters/mean.h"
 
 using namespace filters ;
 
 void seed_rand()
 {
-#ifndef _WIN32
-  //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
-#else
-  srand(GetTickCount());
-#endif
+  std::srand(std::time(0));
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -54,9 +44,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 

--- a/test/test_median.cpp
+++ b/test/test_median.cpp
@@ -28,7 +28,11 @@
  */
 
 #include <gtest/gtest.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#else
+#include <windows.h>
+#endif
 
 #include "filters/median.h"
 
@@ -36,10 +40,14 @@ using namespace filters ;
 
 void seed_rand()
 {
+#ifndef _WIN32
   //Seed random number generator with current microseond count
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
+#else
+  srand(GetTickCount());
+#endif
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)

--- a/test/test_median.cpp
+++ b/test/test_median.cpp
@@ -28,26 +28,15 @@
  */
 
 #include <gtest/gtest.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#else
-#include <windows.h>
-#endif
-
+#include <ctime>
+#include <cstdlib>
 #include "filters/median.h"
 
 using namespace filters ;
 
 void seed_rand()
 {
-#ifndef _WIN32
-  //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
-#else
-  srand(GetTickCount());
-#endif
+  std::srand(std::time(0));
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -55,9 +44,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 

--- a/test/test_params.cpp
+++ b/test/test_params.cpp
@@ -28,7 +28,9 @@
  */
 
 #include <gtest/gtest.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 #include "filters/param_test.h"
 
 using namespace filters ;

--- a/test/test_params.cpp
+++ b/test/test_params.cpp
@@ -28,9 +28,6 @@
  */
 
 #include <gtest/gtest.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#endif
 #include "filters/param_test.h"
 
 using namespace filters ;

--- a/test/test_realtime_circular_buffer.cpp
+++ b/test/test_realtime_circular_buffer.cpp
@@ -28,7 +28,11 @@
  */
 
 #include <gtest/gtest.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#else
+#include <windows.h>
+#endif
 
 #include <vector>
 #include "filters/realtime_circular_buffer.h"
@@ -37,10 +41,14 @@ using namespace filters ;
 
 void seed_rand()
 {
+#ifndef _WIN32
   //Seed random number generator with current microseond count
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
+#else
+  srand(GetTickCount());
+#endif
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)

--- a/test/test_realtime_circular_buffer.cpp
+++ b/test/test_realtime_circular_buffer.cpp
@@ -28,12 +28,8 @@
  */
 
 #include <gtest/gtest.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#else
-#include <windows.h>
-#endif
-
+#include <ctime>
+#include <cstdlib>
 #include <vector>
 #include "filters/realtime_circular_buffer.h"
 
@@ -41,14 +37,7 @@ using namespace filters ;
 
 void seed_rand()
 {
-#ifndef _WIN32
-  //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
-#else
-  srand(GetTickCount());
-#endif
+  std::srand(std::time(0));
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -56,9 +45,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 

--- a/test/test_transfer_function.cpp
+++ b/test/test_transfer_function.cpp
@@ -29,7 +29,9 @@
 
 #include <ros/ros.h>
 #include <gtest/gtest.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 #include <vector>
 #include "filters/transfer_function.h"
 

--- a/test/test_transfer_function.cpp
+++ b/test/test_transfer_function.cpp
@@ -29,9 +29,6 @@
 
 #include <ros/ros.h>
 #include <gtest/gtest.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#endif
 #include <vector>
 #include "filters/transfer_function.h"
 


### PR DESCRIPTION
On Windows, there is no native `gettimeofday()` API so instead use `GetTickCount` to make the seed for random number generation.