### PR TITLE
Reduce dependency on boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ catkin_package(
 ##############################################################################
 
 add_library(real_time_circular_buffer INTERFACE)
-target_include_directories(real_time_circular_buffer INTERFACE ${Boost_INCLUDE_DIRS})
+target_include_directories(real_time_circular_buffer INTERFACE
+  include
+  ${Boost_INCLUDE_DIRS})
 
 # Plugins
 add_library(mean src/mean.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES mean params increment median transfer_function
   CATKIN_DEPENDS roslib roscpp rosconsole pluginlib
+  DEPENDS Boost
 )
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,11 @@ project(filters)
 ##############################################################################
 
 find_package(catkin REQUIRED COMPONENTS pluginlib roslib roscpp rosconsole)
-find_package(Boost COMPONENTS system filesystem thread REQUIRED)
+find_package(Boost REQUIRED)
 
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 ##############################################################################
@@ -28,47 +27,61 @@ catkin_package(
 # Build
 ##############################################################################
 
+add_library(real_time_circular_buffer INTERFACE)
+target_include_directories(real_time_circular_buffer INTERFACE ${Boost_INCLUDE_DIRS})
+
 # Plugins
 add_library(mean src/mean.cpp)
-target_link_libraries(mean ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(mean
+  ${catkin_LIBRARIES}
+  real_time_circular_buffer)
 add_library(params src/test_params.cpp)
-target_link_libraries(params ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(params
+  ${catkin_LIBRARIES}
+  real_time_circular_buffer)
 add_library(increment src/increment.cpp)
-target_link_libraries(increment ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(increment
+  ${catkin_LIBRARIES}
+  real_time_circular_buffer)
 add_library(median src/median.cpp)
-target_link_libraries(median ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(median
+  ${catkin_LIBRARIES}
+  real_time_circular_buffer)
 add_library(transfer_function src/transfer_function.cpp)
-target_link_libraries(transfer_function ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(transfer_function
+  ${catkin_LIBRARIES}
+  real_time_circular_buffer)
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest)
   # Test median filter
   add_executable(median_test EXCLUDE_FROM_ALL test/test_median.cpp )
-  target_link_libraries(median_test median ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES}) 
+  target_link_libraries(median_test median ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
   add_rostest(test/test_median.launch)
 
   # Test transfer function filter
   add_executable(transfer_function_test EXCLUDE_FROM_ALL test/test_transfer_function.cpp)
-  target_link_libraries(transfer_function_test transfer_function ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
+  target_link_libraries(transfer_function_test transfer_function ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
   add_rostest(test/test_transfer_function.launch)
 
   # Test mean filter
   add_executable(mean_test EXCLUDE_FROM_ALL test/test_mean.cpp)
-  target_link_libraries(mean_test mean ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
+  target_link_libraries(mean_test mean ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
   add_rostest(test/test_mean.launch)
 
   # Test params filter
   add_executable(params_test EXCLUDE_FROM_ALL test/test_params.cpp)
-  target_link_libraries(params_test params ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
+  target_link_libraries(params_test params ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
   add_rostest(test/test_params.launch)
 
   # Test plugin loading into filter chain
   add_executable(chain_test EXCLUDE_FROM_ALL test/test_chain.cpp)
-  target_link_libraries(chain_test increment ${Boost_libraries} ${catkin_LIBRARIES} ${GTEST_LIBRARIES}) # Needed for OSX
+  target_link_libraries(chain_test increment ${catkin_LIBRARIES} ${GTEST_LIBRARIES}) # Needed for OSX
   add_rostest(test/test_chain.launch)
 
   # Test realtime safe buffer class
   catkin_add_gtest(realtime_buffer_test EXCLUDE_FROM_ALL test/test_realtime_circular_buffer.cpp)
+  target_link_libraries(realtime_buffer_test real_time_circular_buffer)
 endif()
 
 ##############################################################################

--- a/include/filters/filter_base.h
+++ b/include/filters/filter_base.h
@@ -35,9 +35,6 @@
 #include "ros/console.h"
 #include "ros/ros.h"
 
-#include "boost/scoped_ptr.hpp"
-#include <boost/algorithm/string.hpp>
-
 namespace filters
 {
 

--- a/include/filters/filter_base.h
+++ b/include/filters/filter_base.h
@@ -35,6 +35,8 @@
 #include "ros/console.h"
 #include "ros/ros.h"
 
+#include "boost/scoped_ptr.hpp"
+#include <boost/algorithm/string.hpp>
 
 namespace filters
 {

--- a/include/filters/filter_base.h
+++ b/include/filters/filter_base.h
@@ -35,8 +35,6 @@
 #include "ros/console.h"
 #include "ros/ros.h"
 
-#include "boost/scoped_ptr.hpp"
-#include <boost/algorithm/string.hpp>
 
 namespace filters
 {

--- a/include/filters/filter_chain.h
+++ b/include/filters/filter_chain.h
@@ -32,10 +32,10 @@
 
 #include "ros/ros.h"
 #include "filters/filter_base.h"
+#include <memory>
 #include <pluginlib/class_loader.h>
 #include <sstream>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 namespace filters
 {
@@ -229,7 +229,7 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
-      boost::shared_ptr<filters::FilterBase<T> > p(loader_.createInstance(config[i]["type"]));
+      std::shared_ptr<filters::FilterBase<T> > p(loader_.createInstance(config[i]["type"]));
       if (p.get() == NULL)
         return false;
       result = result &&  p.get()->configure(config[i]);    
@@ -249,7 +249,7 @@ public:
 
 private:
 
-  std::vector<boost::shared_ptr<filters::FilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
+  std::vector<std::shared_ptr<filters::FilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
 
   T buffer0_; ///<! A temporary intermediate buffer
   T buffer1_; ///<! A temporary intermediate buffer
@@ -466,7 +466,7 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
-      boost::shared_ptr<filters::MultiChannelFilterBase<T> > p(loader_.createInstance(config[i]["type"]));
+      std::shared_ptr<filters::MultiChannelFilterBase<T> > p(loader_.createInstance(config[i]["type"]));
       if (p.get() == NULL)
         return false;
       result = result &&  p.get()->configure(size, config[i]);    
@@ -486,7 +486,7 @@ public:
 
 private:
 
-  std::vector<boost::shared_ptr<filters::MultiChannelFilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
+  std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
 
   std::vector<T> buffer0_; ///<! A temporary intermediate buffer
   std::vector<T> buffer1_; ///<! A temporary intermediate buffer

--- a/include/filters/filter_chain.h
+++ b/include/filters/filter_chain.h
@@ -32,10 +32,10 @@
 
 #include "ros/ros.h"
 #include "filters/filter_base.h"
-#include <memory>
 #include <pluginlib/class_loader.h>
 #include <sstream>
 #include <vector>
+#include "boost/shared_ptr.hpp"
 
 namespace filters
 {
@@ -229,7 +229,7 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
-      std::shared_ptr<filters::FilterBase<T> > p(loader_.createInstance(config[i]["type"]));
+      boost::shared_ptr<filters::FilterBase<T> > p(loader_.createInstance(config[i]["type"]));
       if (p.get() == NULL)
         return false;
       result = result &&  p.get()->configure(config[i]);    
@@ -249,7 +249,7 @@ public:
 
 private:
 
-  std::vector<std::shared_ptr<filters::FilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
+  std::vector<boost::shared_ptr<filters::FilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
 
   T buffer0_; ///<! A temporary intermediate buffer
   T buffer1_; ///<! A temporary intermediate buffer
@@ -466,7 +466,7 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
-      std::shared_ptr<filters::MultiChannelFilterBase<T> > p(loader_.createInstance(config[i]["type"]));
+      boost::shared_ptr<filters::MultiChannelFilterBase<T> > p(loader_.createInstance(config[i]["type"]));
       if (p.get() == NULL)
         return false;
       result = result &&  p.get()->configure(size, config[i]);    
@@ -486,7 +486,7 @@ public:
 
 private:
 
-  std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
+  std::vector<boost::shared_ptr<filters::MultiChannelFilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
 
   std::vector<T> buffer0_; ///<! A temporary intermediate buffer
   std::vector<T> buffer1_; ///<! A temporary intermediate buffer

--- a/include/filters/increment.h
+++ b/include/filters/increment.h
@@ -34,8 +34,6 @@
 #include <cstring>
 #include <stdio.h>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "filters/filter_base.h"
 
 namespace filters

--- a/include/filters/mean.h
+++ b/include/filters/mean.h
@@ -34,7 +34,7 @@
 #include <cstring>
 #include <stdio.h>
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 #include "filters/filter_base.h"
 #include "ros/assert.h"
@@ -67,7 +67,7 @@ public:
   virtual bool update( const T & data_in, T& data_out);
   
 protected:
-  boost::scoped_ptr<RealtimeCircularBuffer<T > > data_storage_; ///< Storage for data between updates
+  std::unique_ptr<RealtimeCircularBuffer<T > > data_storage_; ///< Storage for data between updates
   uint32_t last_updated_row_;                     ///< The last row to have been updated by the filter
   T temp_; /// Temporary storage
   uint32_t number_of_observations_;             ///< Number of observations over which to filter
@@ -150,7 +150,7 @@ public:
   virtual bool update( const std::vector<T> & data_in, std::vector<T>& data_out);
   
 protected:
-  boost::scoped_ptr<RealtimeCircularBuffer<std::vector<T> > > data_storage_; ///< Storage for data between updates
+  std::unique_ptr<RealtimeCircularBuffer<std::vector<T> > > data_storage_; ///< Storage for data between updates
   uint32_t last_updated_row_;                     ///< The last row to have been updated by the filter
 
   std::vector<T> temp;  //used for preallocation and copying from non vector source

--- a/include/filters/median.h
+++ b/include/filters/median.h
@@ -34,7 +34,7 @@
 #include <sstream>
 #include <cstdio>
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 #include "filters/filter_base.h"
 
@@ -114,7 +114,7 @@ public:
   
 protected:
   std::vector<T> temp_storage_;                       ///< Preallocated storage for the list to sort
-  boost::scoped_ptr<RealtimeCircularBuffer<T > > data_storage_;                       ///< Storage for data between updates
+  std::unique_ptr<RealtimeCircularBuffer<T > > data_storage_;                       ///< Storage for data between updates
   
   T temp;  //used for preallocation and copying from non vector source
 
@@ -198,7 +198,7 @@ public:
   
 protected:
   std::vector<T> temp_storage_;                       ///< Preallocated storage for the list to sort
-  boost::scoped_ptr<RealtimeCircularBuffer<std::vector<T> > > data_storage_;                       ///< Storage for data between updates
+  std::unique_ptr<RealtimeCircularBuffer<std::vector<T> > > data_storage_;                       ///< Storage for data between updates
   
   std::vector<T> temp;  //used for preallocation and copying from non vector source
 

--- a/include/filters/param_test.h
+++ b/include/filters/param_test.h
@@ -34,8 +34,6 @@
 #include <cstring>
 #include <stdio.h>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "filters/filter_base.h"
 #include "ros/assert.h"
 

--- a/include/filters/transfer_function.h
+++ b/include/filters/transfer_function.h
@@ -34,10 +34,9 @@
 
 #include <stdint.h>
 #include <math.h>
+#include <memory>
 #include <vector>
 #include <string>
-
-#include <boost/scoped_ptr.hpp>
 
 #include "filters/filter_base.h"
 #include "filters/realtime_circular_buffer.h"
@@ -99,8 +98,8 @@ public:
 
 protected:
 
-  boost::scoped_ptr<RealtimeCircularBuffer<T > > input_buffer_; //The input sample history.
-  boost::scoped_ptr<RealtimeCircularBuffer<T > > output_buffer_; //The output sample history.
+  std::unique_ptr<RealtimeCircularBuffer<T > > input_buffer_; //The input sample history.
+  std::unique_ptr<RealtimeCircularBuffer<T > > output_buffer_; //The output sample history.
 
   T  temp_; //used for storage and preallocation
 
@@ -250,8 +249,8 @@ public:
 
 protected:
 
-  boost::scoped_ptr<RealtimeCircularBuffer<std::vector<T> > > input_buffer_; //The input sample history.
-  boost::scoped_ptr<RealtimeCircularBuffer<std::vector<T> > > output_buffer_; //The output sample history.
+  std::unique_ptr<RealtimeCircularBuffer<std::vector<T> > > input_buffer_; //The input sample history.
+  std::unique_ptr<RealtimeCircularBuffer<std::vector<T> > > output_buffer_; //The output sample history.
 
   std::vector<T>  temp_; //used for storage and preallocation
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>boost</run_depend>
 
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -18,11 +18,13 @@
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>boost</build_depend>
 
   <run_depend>roslib</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>boost</run_depend>
 
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,6 @@
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
-  <run_depend>boost</run_depend>
 
 
   <export>


### PR DESCRIPTION
* Adds missing dependency on `boost` rosdep key
  * ~~Doesn't appear to be needed at run time if `boost::circular_buffer` is header only~~ actually filter_chain gets a `boost::shared_ptr` from pluginlib
* Replaces use of `boost::scoped_ptr` with `std::unique_ptr`
* Consolidates references to boost in CMake to an interface target