### PR TITLE
Make getParam() functions of FilterBase const

### DIFF
--- a/include/filters/filter_base.h
+++ b/include/filters/filter_base.h
@@ -118,9 +118,9 @@ protected:
    * \param name The name of the parameter
    * \param value The string to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string& name, std::string& value)
+  bool getParam(const std::string& name, std::string& value) const
   {
-    string_map_t::iterator it = params_.find(name);
+    string_map_t::const_iterator it = params_.find(name);
     if (it == params_.end())
     {
       return false;
@@ -131,7 +131,8 @@ protected:
       return false;
     }
 
-    value = std::string(it->second);
+    auto tmp = it->second;
+    value = std::string(tmp);
     return true;
   }
 
@@ -139,9 +140,9 @@ protected:
    * \param name The name of the parameter
    * \param value The boolean to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string& name, bool& value)
+  bool getParam(const std::string& name, bool& value) const
   {
-    string_map_t::iterator it = params_.find(name);
+    string_map_t::const_iterator it = params_.find(name);
     if (it == params_.end())
     {
       return false;
@@ -152,7 +153,8 @@ protected:
       return false;
     }
 
-    value = (bool)(it->second);
+    auto tmp = it->second;
+    value = (bool)(tmp);
     return true;
   }
 
@@ -160,9 +162,9 @@ protected:
    * \param name The name of the parameter
    * \param value The double to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string&name, double& value)
+  bool getParam(const std::string&name, double& value) const
   {
-    string_map_t::iterator it = params_.find(name);
+    string_map_t::const_iterator it = params_.find(name);
     if (it == params_.end())
     {
       return false;
@@ -173,7 +175,8 @@ protected:
       return false;
     }
 
-    value = it->second.getType() == XmlRpc::XmlRpcValue::TypeInt ? (int)(it->second) : (double)(it->second);
+    auto tmp = it->second;
+    value = it->second.getType() == XmlRpc::XmlRpcValue::TypeInt ? (int)(tmp) : (double)(tmp);
     return true;
   }
 
@@ -181,9 +184,9 @@ protected:
    * \param name The name of the parameter
    * \param value The int to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string&name, int& value)
+  bool getParam(const std::string&name, int& value) const
   {
-    string_map_t::iterator it = params_.find(name);
+    string_map_t::const_iterator it = params_.find(name);
     if (it == params_.end())
     {
       return false;
@@ -194,7 +197,8 @@ protected:
       return false;
     }
 
-    value = it->second;
+    auto tmp = it->second;
+    value = tmp;
     return true;
   }
 
@@ -202,7 +206,7 @@ protected:
    * \param name The name of the parameter
    * \param value The int to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string&name, unsigned  int& value)
+  bool getParam(const std::string&name, unsigned  int& value) const
   {
     int signed_value;
     if (!getParam(name, signed_value))
@@ -217,9 +221,9 @@ protected:
    * \param name The name of the parameter
    * \param value The std::vector<double> to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string&name, std::vector<double>& value)
+  bool getParam(const std::string&name, std::vector<double>& value) const
   {
-    string_map_t::iterator it = params_.find(name);
+    string_map_t::const_iterator it = params_.find(name);
     if (it == params_.end())
     {
       return false;
@@ -251,9 +255,9 @@ protected:
    * \param name The name of the parameter
    * \param value The std::vector<sgring> to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string&name, std::vector<std::string>& value)
+  bool getParam(const std::string&name, std::vector<std::string>& value) const
   {
-    string_map_t::iterator it = params_.find(name);
+    string_map_t::const_iterator it = params_.find(name);
     if (it == params_.end())
     {
       return false;
@@ -284,15 +288,16 @@ protected:
    * \param name The name of the parameter
    * \param value The XmlRpcValue to set with the value
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string& name, XmlRpc::XmlRpcValue& value)
+  bool getParam(const std::string& name, XmlRpc::XmlRpcValue& value) const
   {
-    string_map_t::iterator it = params_.find(name);
+    string_map_t::const_iterator it = params_.find(name);
     if (it == params_.end())
     {
       return false;
     }
 
-    value = it->second;
+    auto tmp = it->second;
+    value = tmp;
     return true;
   }
   


### PR DESCRIPTION
There's no reason for them to be non-const.