### PR TITLE
Added support for inplace filters.

### DIFF
--- a/default_plugins.xml
+++ b/default_plugins.xml
@@ -1,87 +1,87 @@
 <class_libraries>
   <library path="lib/libmedian">
-    <class name="filters/MultiChannelMedianFilterDouble" type="filters::MultiChannelMedianFilter<double>"
-	    base_class_type="filters::MultiChannelFilterBase<double>">
+    <class name="filters/MultiChannelMedianFilterDouble" type="filters::MultiChannelMedianFilter&lt;double&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
       <description>
 	This is a median filter which works on a stream of std::vector of doubles.
       </description>
     </class>
-    <class name="filters/MedianFilterDouble" type="filters::MedianFilter<double>"
-	    base_class_type="filters::FilterBase<double>">
+    <class name="filters/MedianFilterDouble" type="filters::MedianFilter&lt;double&gt;"
+	    base_class_type="filters::FilterBase&lt;double&gt;">
       <description>
 	This is a median filter which works on a stream of doubles.
       </description>
     </class>
-    <class name="filters/MultiChannelMedianFilterFloat" type="filters::MultiChannelMedianFilter<float>"
-	    base_class_type="filters::MultiChannelFilterBase<float>">
+    <class name="filters/MultiChannelMedianFilterFloat" type="filters::MultiChannelMedianFilter&lt;float&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;float&gt;">
       <description>
 	This is a median filter which works on a stream of std::vector of floats.
       </description>
     </class>
-    <class name="filters/MedianFilterFloat" type="filters::MedianFilter<float>"
-	    base_class_type="filters::FilterBase<float>">
+    <class name="filters/MedianFilterFloat" type="filters::MedianFilter&lt;float&gt;"
+	    base_class_type="filters::FilterBase&lt;float&gt;">
       <description>
 	This is a median filter which works on a stream of floats.
       </description>
     </class>
   </library>
   <library path="lib/libmean">
-    <class name="filters/MeanFilterDouble" type="filters::MeanFilter<double>"
-	    base_class_type="filters::FilterBase<double>">
+    <class name="filters/MeanFilterDouble" type="filters::MeanFilter&lt;double&gt;"
+	    base_class_type="filters::FilterBase&lt;double&gt;">
       <description>
 	This is a mean filter which works on a stream of doubles.
       </description>
     </class>
-    <class name="filters/MeanFilterFloat" type="filters::MeanFilter<float>"
-	    base_class_type="filters::FilterBase<float>">
+    <class name="filters/MeanFilterFloat" type="filters::MeanFilter&lt;float&gt;"
+	    base_class_type="filters::FilterBase&lt;float&gt;">
       <description>
 	This is a mean filter which works on a stream of floats.
       </description>
     </class>
-    <class name="filters/MultiChannelMeanFilterDouble" type="filters::MultiChannelMeanFilter<double>"
-	    base_class_type="filters::MultiChannelFilterBase<double>">
+    <class name="filters/MultiChannelMeanFilterDouble" type="filters::MultiChannelMeanFilter&lt;double&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
       <description>
 	This is a mean filter which works on a stream of vectors of doubles.
       </description>
     </class>
-    <class name="filters/MultiChannelMeanFilterFloat" type="filters::MultiChannelMeanFilter<float>"
-	    base_class_type="filters::MultiChannelFilterBase<float>">
+    <class name="filters/MultiChannelMeanFilterFloat" type="filters::MultiChannelMeanFilter&lt;float&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;float&gt;">
       <description>
 	This is a mean filter which works on a stream of vectors of floats.
       </description>
     </class>
   </library>
   <library path="lib/libtest_param">
-    <class name="filters/ParamTest" type="filters::ParamTest<double>"
-	    base_class_type="filters::FilterBase<double>">
+    <class name="filters/ParamTest" type="filters::ParamTest&lt;double&gt;"
+	    base_class_type="filters::FilterBase&lt;double&gt;">
       <description>
 	This is a filter designed to test parameter readings.  It's not useful.
       </description>
     </class>
   </library>
   <library path="lib/libincrement">
-    <class name="filters/IncrementFilterInt" type="filters::IncrementFilter<int>"
-	    base_class_type="filters::FilterBase<int>">
+    <class name="filters/IncrementFilterInt" type="filters::IncrementFilter&lt;int&gt;"
+	    base_class_type="filters::FilterBase&lt;int&gt;">
       <description>
 	This is a increment filter which works on a stream of ints.
       </description>
     </class>
-    <class name="filters/MultiChannelIncrementFilterInt" type="filters::MultiChannelIncrementFilter<int>"
-	    base_class_type="filters::MultiChannelFilterBase<int>">
+    <class name="filters/MultiChannelIncrementFilterInt" type="filters::MultiChannelIncrementFilter&lt;int&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;int&gt;">
       <description>
 	This is a increment filter which works on a stream of vectors of ints.
       </description>
     </class>
   </library>
   <library path="lib/libtransfer_function">
-    <class name="filters/MultiChannelTransferFunctionFilterDouble" type="filters::MultiChannelTransferFunctionFilter<double>"
-	    base_class_type="filters::MultiChannelFilterBase<double>">
+    <class name="filters/MultiChannelTransferFunctionFilterDouble" type="filters::MultiChannelTransferFunctionFilter&lt;double&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
       <description>
-	This is a transfer filter which works on a stream of doubles.
+	This is a transfer filter which works on a stream of vectors of doubles.
       </description>
     </class>
-    <class name="filters/TransferFunctionFilterDouble" type="filters::SingleChannelTransferFunctionFilter<double>"
-	    base_class_type="filters::FilterBase<double>">
+    <class name="filters/TransferFunctionFilterDouble" type="filters::SingleChannelTransferFunctionFilter&lt;double&gt;"
+	    base_class_type="filters::FilterBase&lt;double&gt;">
       <description>
 	This is a transfer filter which works on a stream of doubles.
       </description>

--- a/default_plugins.xml
+++ b/default_plugins.xml
@@ -24,6 +24,30 @@
 	This is a median filter which works on a stream of floats.
       </description>
     </class>
+    <class name="filters/InplaceMultiChannelMedianFilterDouble" type="filters::InplaceMultiChannelMedianFilter&lt;double&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
+      <description>
+	This is a median filter which works on a stream of std::vector of doubles.
+      </description>
+    </class>
+    <class name="filters/InplaceMedianFilterDouble" type="filters::InplaceMedianFilter&lt;double&gt;"
+	    base_class_type="filters::FilterBase&lt;double&gt;">
+      <description>
+	This is a median filter which works on a stream of doubles.
+      </description>
+    </class>
+    <class name="filters/InplaceMultiChannelMedianFilterFloat" type="filters::InplaceMultiChannelMedianFilter&lt;float&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;float&gt;">
+      <description>
+	This is a median filter which works on a stream of std::vector of floats.
+      </description>
+    </class>
+    <class name="filters/InplaceMedianFilterFloat" type="filters::InplaceMedianFilter&lt;float&gt;"
+	    base_class_type="filters::FilterBase&lt;float&gt;">
+      <description>
+	This is a median filter which works on a stream of floats.
+      </description>
+    </class>
   </library>
   <library path="lib/libmean">
     <class name="filters/MeanFilterDouble" type="filters::MeanFilter&lt;double&gt;"
@@ -45,6 +69,30 @@
       </description>
     </class>
     <class name="filters/MultiChannelMeanFilterFloat" type="filters::MultiChannelMeanFilter&lt;float&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;float&gt;">
+      <description>
+	This is a mean filter which works on a stream of vectors of floats.
+      </description>
+    </class>
+    <class name="filters/InplaceMeanFilterDouble" type="filters::InplaceMeanFilter&lt;double&gt;"
+	    base_class_type="filters::FilterBase&lt;double&gt;">
+      <description>
+	This is a mean filter which works on a stream of doubles.
+      </description>
+    </class>
+    <class name="filters/InplaceMeanFilterFloat" type="filters::InplaceMeanFilter&lt;float&gt;"
+	    base_class_type="filters::FilterBase&lt;float&gt;">
+      <description>
+	This is a mean filter which works on a stream of floats.
+      </description>
+    </class>
+    <class name="filters/InplaceMultiChannelMeanFilterDouble" type="filters::InplaceMultiChannelMeanFilter&lt;double&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
+      <description>
+	This is a mean filter which works on a stream of vectors of doubles.
+      </description>
+    </class>
+    <class name="filters/InplaceMultiChannelMeanFilterFloat" type="filters::InplaceMultiChannelMeanFilter&lt;float&gt;"
 	    base_class_type="filters::MultiChannelFilterBase&lt;float&gt;">
       <description>
 	This is a mean filter which works on a stream of vectors of floats.
@@ -72,6 +120,18 @@
 	This is a increment filter which works on a stream of vectors of ints.
       </description>
     </class>
+    <class name="filters/InplaceIncrementFilterInt" type="filters::InplaceIncrementFilter&lt;int&gt;"
+	    base_class_type="filters::FilterBase&lt;int&gt;">
+      <description>
+	This is a increment filter which works on a stream of ints.
+      </description>
+    </class>
+    <class name="filters/InplaceMultiChannelIncrementFilterInt" type="filters::InplaceMultiChannelIncrementFilter&lt;int&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;int&gt;">
+      <description>
+	This is a increment filter which works on a stream of vectors of ints.
+      </description>
+    </class>
   </library>
   <library path="lib/libtransfer_function">
     <class name="filters/MultiChannelTransferFunctionFilterDouble" type="filters::MultiChannelTransferFunctionFilter&lt;double&gt;"
@@ -81,6 +141,18 @@
       </description>
     </class>
     <class name="filters/TransferFunctionFilterDouble" type="filters::SingleChannelTransferFunctionFilter&lt;double&gt;"
+	    base_class_type="filters::FilterBase&lt;double&gt;">
+      <description>
+	This is a transfer filter which works on a stream of doubles.
+      </description>
+    </class>
+    <class name="filters/InplaceMultiChannelTransferFunctionFilterDouble" type="filters::InplaceMultiChannelTransferFunctionFilter&lt;double&gt;"
+	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
+      <description>
+	This is a transfer filter which works on a stream of vectors of doubles.
+      </description>
+    </class>
+    <class name="filters/InplaceTransferFunctionFilterDouble" type="filters::InplaceSingleChannelTransferFunctionFilter&lt;double&gt;"
 	    base_class_type="filters::FilterBase&lt;double&gt;">
       <description>
 	This is a transfer filter which works on a stream of doubles.

--- a/include/filters/filter_base.h
+++ b/include/filters/filter_base.h
@@ -373,6 +373,21 @@ protected:
   }
 };
 
+template <typename T>
+class InplaceFilterBase : public FilterBase<T>
+{
+public:
+  using FilterBase<T>::update;
+
+  /** \brief Filter the provided data in-place.
+   * \param data A reference to the data.
+   */
+  virtual bool update(T& data)
+  {
+    return this->update(data, data);
+  };
+};
+
 
 template <typename T>
 class MultiChannelFilterBase : public FilterBase<T>
@@ -454,6 +469,27 @@ protected:
   unsigned int number_of_channels_;
   
 
+};
+
+template <typename T>
+class InplaceMultiChannelFilterBase : public MultiChannelFilterBase<T>
+{
+public:
+  using MultiChannelFilterBase<T>::update;
+
+  /** \brief Filter the provided data in-place.
+   * \param data A reference to the data.
+   */
+  virtual bool update(std::vector<T>& data)
+  {
+    return this->update(data, data);
+  };
+
+  virtual bool update(T& data)
+  {
+    ROS_ERROR("THIS IS A MULTI FILTER DON'T CALL SINGLE FORM OF UPDATE");
+    return false;
+  };
 };
 
 }

--- a/include/filters/filter_base.h
+++ b/include/filters/filter_base.h
@@ -374,18 +374,13 @@ protected:
 };
 
 template <typename T>
-class InplaceFilterBase : public FilterBase<T>
+class InplaceFilterBase
 {
 public:
-  using FilterBase<T>::update;
-
   /** \brief Filter the provided data in-place.
    * \param data A reference to the data.
    */
-  virtual bool update(T& data)
-  {
-    return this->update(data, data);
-  };
+  virtual bool update(T& data) = 0;
 };
 
 
@@ -472,18 +467,13 @@ protected:
 };
 
 template <typename T>
-class InplaceMultiChannelFilterBase : public MultiChannelFilterBase<T>
+class InplaceMultiChannelFilterBase
 {
 public:
-  using MultiChannelFilterBase<T>::update;
-
   /** \brief Filter the provided data in-place.
    * \param data A reference to the data.
    */
-  virtual bool update(std::vector<T>& data)
-  {
-    return this->update(data, data);
-  };
+  virtual bool update(std::vector<T>& data) = 0;
 
   virtual bool update(T& data)
   {

--- a/include/filters/filter_chain.h
+++ b/include/filters/filter_chain.h
@@ -109,7 +109,7 @@ public:
       if (result == false) {return false; };//don't keep processing on failure
 
       if (is_filter1_inplace)
-        result = result && inplace_filter1->update(data_out);
+        result = result && inplace_filter1->updateInplace(data_out);
       else
         result = result && reference_pointers_[1]->update(buffer0_, data_out);
     }
@@ -134,7 +134,7 @@ public:
         const auto inplace_filter = dynamic_cast<InplaceFilterBase<T>*>(reference_pointers_[i].get());
 
         if (inplace_filter != nullptr)
-          result = result && inplace_filter->update(*curBuf);
+          result = result && inplace_filter->updateInplace(*curBuf);
         else {
           result = result && reference_pointers_[i]->update(*curBuf, *nextBuf);
           std::swap(curBuf, nextBuf);
@@ -145,7 +145,7 @@ public:
 
       // if all filters are inplace, curBuf has been pointed to data_out in the beginning and hasn't been swapped since then
       if (all_filters_are_inplace)
-        result = result && dynamic_cast<InplaceFilterBase<T>*>(reference_pointers_.back().get())->update(*curBuf);
+        result = result && dynamic_cast<InplaceFilterBase<T>*>(reference_pointers_.back().get())->updateInplace(*curBuf);
       else
         result = result && reference_pointers_.back()->update(*curBuf, data_out);
     }
@@ -171,7 +171,7 @@ public:
         const auto inplace_filter = dynamic_cast<InplaceFilterBase<T>*>(filter.get());
 
         if (inplace_filter != nullptr)
-          result = result && inplace_filter->update(*curBuf);
+          result = result && inplace_filter->updateInplace(*curBuf);
         else {
           result = result && filter->update(*curBuf, *nextBuf);
           std::swap(curBuf, nextBuf);
@@ -384,7 +384,7 @@ public:
       if (result == false) {return false; };//don't keep processing on failure
 
       if (is_filter1_inplace)
-        result = result && inplace_filter1->update(data_out);
+        result = result && inplace_filter1->updateInplace(data_out);
       else
         result = result && reference_pointers_[1]->update(buffer0_, data_out);
     }
@@ -408,7 +408,7 @@ public:
         const auto inplace_filter = dynamic_cast<InplaceMultiChannelFilterBase<T>*>(reference_pointers_[i].get());
 
         if (inplace_filter != nullptr)
-          result = result && inplace_filter->update(*curBuf);
+          result = result && inplace_filter->updateInplace(*curBuf);
         else {
           result = result && reference_pointers_[i]->update(*curBuf, *nextBuf);
           std::swap(curBuf, nextBuf);
@@ -419,7 +419,7 @@ public:
 
       // if all filters are inplace, curBuf has been pointed to data_out in the beginning and hasn't been swapped since then
       if (all_filters_are_inplace)
-        result = result && dynamic_cast<InplaceMultiChannelFilterBase<T>*>(reference_pointers_.back().get())->update(*curBuf);
+        result = result && dynamic_cast<InplaceMultiChannelFilterBase<T>*>(reference_pointers_.back().get())->updateInplace(*curBuf);
       else
         result = result && reference_pointers_.back()->update(*curBuf, data_out);
     }
@@ -445,7 +445,7 @@ public:
         const auto inplace_filter = dynamic_cast<InplaceMultiChannelFilterBase<T>*>(filter.get());
 
         if (inplace_filter != nullptr)
-          result = result && inplace_filter->update(*curBuf);
+          result = result && inplace_filter->updateInplace(*curBuf);
         else {
           result = result && filter->update(*curBuf, *nextBuf);
           std::swap(curBuf, nextBuf);

--- a/include/filters/increment.h
+++ b/include/filters/increment.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef FILTERS_MEAN_H
-#define FILTERS_MEAN_H
+#ifndef FILTERS_INCREMENT_H
+#define FILTERS_INCREMENT_H
 
 #include <stdint.h>
 #include <cstring>
@@ -45,7 +45,7 @@ namespace filters
  *
  */
 template <typename T>
-class IncrementFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
+class IncrementFilter: public FilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -62,9 +62,14 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const T & data_in, T& data_out);
-  bool update(T& data) override;
+
 };
 
+template <typename T>
+class InplaceIncrementFilter: public IncrementFilter<T>, public InplaceFilterBase<T>
+{
+  bool updateInplace(T& data) override;
+};
 
 template <typename T>
 IncrementFilter<T>::IncrementFilter()
@@ -93,7 +98,7 @@ bool IncrementFilter<T>::update(const T & data_in, T& data_out)
 };
 
 template<typename T>
-bool IncrementFilter<T>::update(T& data)
+bool InplaceIncrementFilter<T>::updateInplace(T& data)
 {
   return this->update(data, data);
 }
@@ -102,7 +107,7 @@ bool IncrementFilter<T>::update(T& data)
  *
  */
 template <typename T>
-class MultiChannelIncrementFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
+class MultiChannelIncrementFilter: public MultiChannelFilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -119,15 +124,19 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const std::vector<T> & data_in, std::vector<T>& data_out);
-  bool update(std::vector<T>& data) override;
 
 protected:
   using MultiChannelFilterBase<T>::number_of_channels_;           ///< Number of elements per observation
 
-  
-  
+
+
 };
 
+template <typename T>
+class InplaceMultiChannelIncrementFilter: public MultiChannelIncrementFilter<T>, public InplaceMultiChannelFilterBase<T>
+{
+  bool updateInplace(std::vector<T>& data) override;
+};
 
 template <typename T>
 MultiChannelIncrementFilter<T>::MultiChannelIncrementFilter()
@@ -169,7 +178,7 @@ bool MultiChannelIncrementFilter<T>::update(const std::vector<T> & data_in, std:
 };
 
 template<typename T>
-bool MultiChannelIncrementFilter<T>::update(std::vector<T>& data)
+bool InplaceMultiChannelIncrementFilter<T>::updateInplace(std::vector<T>& data)
 {
   return this->update(data, data);
 }

--- a/include/filters/increment.h
+++ b/include/filters/increment.h
@@ -45,7 +45,7 @@ namespace filters
  *
  */
 template <typename T>
-class IncrementFilter: public FilterBase <T>
+class IncrementFilter: public InplaceFilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -96,7 +96,7 @@ bool IncrementFilter<T>::update(const T & data_in, T& data_out)
  *
  */
 template <typename T>
-class MultiChannelIncrementFilter: public MultiChannelFilterBase <T>
+class MultiChannelIncrementFilter: public InplaceMultiChannelFilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */

--- a/include/filters/increment.h
+++ b/include/filters/increment.h
@@ -45,7 +45,7 @@ namespace filters
  *
  */
 template <typename T>
-class IncrementFilter: public InplaceFilterBase <T>
+class IncrementFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -62,7 +62,7 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const T & data_in, T& data_out);
-  
+  bool update(T& data) override;
 };
 
 
@@ -92,11 +92,17 @@ bool IncrementFilter<T>::update(const T & data_in, T& data_out)
   return true;
 };
 
+template<typename T>
+bool IncrementFilter<T>::update(T& data)
+{
+  return this->update(data, data);
+}
+
 /** \brief A increment filter which works on arrays.
  *
  */
 template <typename T>
-class MultiChannelIncrementFilter: public InplaceMultiChannelFilterBase <T>
+class MultiChannelIncrementFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -113,7 +119,8 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const std::vector<T> & data_in, std::vector<T>& data_out);
-  
+  bool update(std::vector<T>& data) override;
+
 protected:
   using MultiChannelFilterBase<T>::number_of_channels_;           ///< Number of elements per observation
 
@@ -160,6 +167,12 @@ bool MultiChannelIncrementFilter<T>::update(const std::vector<T> & data_in, std:
 
   return true;
 };
+
+template<typename T>
+bool MultiChannelIncrementFilter<T>::update(std::vector<T>& data)
+{
+  return this->update(data, data);
+}
 
 }
 #endif// FILTERS_INCREMENT_H

--- a/include/filters/mean.h
+++ b/include/filters/mean.h
@@ -48,7 +48,7 @@ namespace filters
  *
  */
 template <typename T>
-class MeanFilter: public FilterBase <T>
+class MeanFilter: public InplaceFilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -131,7 +131,7 @@ bool MeanFilter<T>::update(const T & data_in, T& data_out)
  *
  */
 template <typename T>
-class MultiChannelMeanFilter: public MultiChannelFilterBase <T>
+class MultiChannelMeanFilter: public InplaceMultiChannelFilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */

--- a/include/filters/mean.h
+++ b/include/filters/mean.h
@@ -48,7 +48,7 @@ namespace filters
  *
  */
 template <typename T>
-class MeanFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
+class MeanFilter: public filters::FilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -65,7 +65,6 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const T & data_in, T& data_out);
-  bool update(T& data) override;
 
 protected:
   boost::scoped_ptr<RealtimeCircularBuffer<T > > data_storage_; ///< Storage for data between updates
@@ -75,6 +74,11 @@ protected:
   
 };
 
+template <typename T>
+class InplaceMeanFilter: public MeanFilter<T>, public InplaceFilterBase<T>
+{
+  bool updateInplace(T& data) override;
+};
 
 template <typename T>
 MeanFilter<T>::MeanFilter():
@@ -129,16 +133,16 @@ bool MeanFilter<T>::update(const T & data_in, T& data_out)
 };
 
 template<typename T>
-bool MeanFilter<T>::update(T& data)
+bool InplaceMeanFilter<T>::updateInplace(T& data)
 {
-  return update(data, data);
+  return this->update(data, data);
 }
 
 /** \brief A mean filter which works on double arrays.
  *
  */
 template <typename T>
-class MultiChannelMeanFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
+class MultiChannelMeanFilter: public filters::MultiChannelFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -155,7 +159,6 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const std::vector<T> & data_in, std::vector<T>& data_out);
-  bool update(std::vector<T>& data) override;
 
 protected:
   boost::scoped_ptr<RealtimeCircularBuffer<std::vector<T> > > data_storage_; ///< Storage for data between updates
@@ -170,6 +173,11 @@ protected:
   
 };
 
+template <typename T>
+class InplaceMultiChannelMeanFilter: public MultiChannelMeanFilter<T>, public InplaceMultiChannelFilterBase<T>
+{
+  bool updateInplace(std::vector<T>& data) override;
+};
 
 template <typename T>
 MultiChannelMeanFilter<T>::MultiChannelMeanFilter():
@@ -236,9 +244,9 @@ bool MultiChannelMeanFilter<T>::update(const std::vector<T> & data_in, std::vect
 };
 
 template<typename T>
-bool MultiChannelMeanFilter<T>::update(std::vector<T>& data)
+bool InplaceMultiChannelMeanFilter<T>::updateInplace(std::vector<T>& data)
 {
-  return update(data, data);
+  return this->update(data, data);
 }
 
 }

--- a/include/filters/mean.h
+++ b/include/filters/mean.h
@@ -48,7 +48,7 @@ namespace filters
  *
  */
 template <typename T>
-class MeanFilter: public InplaceFilterBase <T>
+class MeanFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -65,7 +65,8 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const T & data_in, T& data_out);
-  
+  bool update(T& data) override;
+
 protected:
   boost::scoped_ptr<RealtimeCircularBuffer<T > > data_storage_; ///< Storage for data between updates
   uint32_t last_updated_row_;                     ///< The last row to have been updated by the filter
@@ -127,11 +128,17 @@ bool MeanFilter<T>::update(const T & data_in, T& data_out)
   return true;
 };
 
+template<typename T>
+bool MeanFilter<T>::update(T& data)
+{
+  return update(data, data);
+}
+
 /** \brief A mean filter which works on double arrays.
  *
  */
 template <typename T>
-class MultiChannelMeanFilter: public InplaceMultiChannelFilterBase <T>
+class MultiChannelMeanFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -148,7 +155,8 @@ public:
    * \param data_out T array with length width
    */
   virtual bool update( const std::vector<T> & data_in, std::vector<T>& data_out);
-  
+  bool update(std::vector<T>& data) override;
+
 protected:
   boost::scoped_ptr<RealtimeCircularBuffer<std::vector<T> > > data_storage_; ///< Storage for data between updates
   uint32_t last_updated_row_;                     ///< The last row to have been updated by the filter
@@ -226,6 +234,12 @@ bool MultiChannelMeanFilter<T>::update(const std::vector<T> & data_in, std::vect
 
   return true;
 };
+
+template<typename T>
+bool MultiChannelMeanFilter<T>::update(std::vector<T>& data)
+{
+  return update(data, data);
+}
 
 }
 #endif// FILTERS_MEAN_H

--- a/include/filters/median.h
+++ b/include/filters/median.h
@@ -94,7 +94,7 @@ elem_type kth_smallest(elem_type a[], int n, int k)
  *
  */
 template <typename T>
-class MedianFilter: public filters::InplaceFilterBase <T>
+class MedianFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -111,7 +111,8 @@ public:
    * \param data_out double array with length width
    */
   virtual bool update(const T& data_in, T& data_out);
-  
+  bool update(T& data) override;
+
 protected:
   std::vector<T> temp_storage_;                       ///< Preallocated storage for the list to sort
   boost::scoped_ptr<RealtimeCircularBuffer<T > > data_storage_;                       ///< Storage for data between updates
@@ -174,11 +175,18 @@ bool MedianFilter<T>::update(const T& data_in, T& data_out)
 
   return true;
 };
+
+template<typename T>
+bool MedianFilter<T>::update(T& data)
+{
+  return update(data, data);
+}
+
 /** \brief A median filter which works on arrays.
  *
  */
 template <typename T>
-class MultiChannelMedianFilter: public filters::InplaceMultiChannelFilterBase <T>
+class MultiChannelMedianFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -195,7 +203,8 @@ public:
    * \param data_out double array with length width
    */
   virtual bool update(const std::vector<T>& data_in, std::vector<T>& data_out);
-  
+  bool update(std::vector<T>& data) override;
+
 protected:
   std::vector<T> temp_storage_;                       ///< Preallocated storage for the list to sort
   boost::scoped_ptr<RealtimeCircularBuffer<std::vector<T> > > data_storage_;                       ///< Storage for data between updates
@@ -264,6 +273,12 @@ bool MultiChannelMedianFilter<T>::update(const std::vector<T>& data_in, std::vec
 
   return true;
 };
+
+template<typename T>
+bool MultiChannelMedianFilter<T>::update(std::vector<T>& data)
+{
+  return update(data, data);
+}
 
 
 }

--- a/include/filters/median.h
+++ b/include/filters/median.h
@@ -94,7 +94,7 @@ elem_type kth_smallest(elem_type a[], int n, int k)
  *
  */
 template <typename T>
-class MedianFilter: public filters::FilterBase <T>
+class MedianFilter: public filters::InplaceFilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -178,7 +178,7 @@ bool MedianFilter<T>::update(const T& data_in, T& data_out)
  *
  */
 template <typename T>
-class MultiChannelMedianFilter: public filters::MultiChannelFilterBase <T>
+class MultiChannelMedianFilter: public filters::InplaceMultiChannelFilterBase <T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */

--- a/include/filters/median.h
+++ b/include/filters/median.h
@@ -94,7 +94,7 @@ elem_type kth_smallest(elem_type a[], int n, int k)
  *
  */
 template <typename T>
-class MedianFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
+class MedianFilter: public filters::FilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -111,7 +111,6 @@ public:
    * \param data_out double array with length width
    */
   virtual bool update(const T& data_in, T& data_out);
-  bool update(T& data) override;
 
 protected:
   std::vector<T> temp_storage_;                       ///< Preallocated storage for the list to sort
@@ -122,6 +121,12 @@ protected:
 
   uint32_t number_of_observations_;             ///< Number of observations over which to filter
 
+};
+
+template <typename T>
+class InplaceMedianFilter: public MedianFilter<T>, public InplaceFilterBase<T>
+{
+  bool updateInplace(T& data) override;
 };
 
 template <typename T>
@@ -177,16 +182,16 @@ bool MedianFilter<T>::update(const T& data_in, T& data_out)
 };
 
 template<typename T>
-bool MedianFilter<T>::update(T& data)
+bool InplaceMedianFilter<T>::updateInplace(T& data)
 {
-  return update(data, data);
+  return this->update(data, data);
 }
 
 /** \brief A median filter which works on arrays.
  *
  */
 template <typename T>
-class MultiChannelMedianFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
+class MultiChannelMedianFilter: public filters::MultiChannelFilterBase<T>
 {
 public:
   /** \brief Construct the filter with the expected width and height */
@@ -203,7 +208,6 @@ public:
    * \param data_out double array with length width
    */
   virtual bool update(const std::vector<T>& data_in, std::vector<T>& data_out);
-  bool update(std::vector<T>& data) override;
 
 protected:
   std::vector<T> temp_storage_;                       ///< Preallocated storage for the list to sort
@@ -214,6 +218,12 @@ protected:
 
   uint32_t number_of_observations_;             ///< Number of observations over which to filter
 
+};
+
+template <typename T>
+class InplaceMultiChannelMedianFilter: public MultiChannelMedianFilter<T>, public InplaceMultiChannelFilterBase<T>
+{
+  bool updateInplace(std::vector<T>& data) override;
 };
 
 template <typename T>
@@ -275,9 +285,9 @@ bool MultiChannelMedianFilter<T>::update(const std::vector<T>& data_in, std::vec
 };
 
 template<typename T>
-bool MultiChannelMedianFilter<T>::update(std::vector<T>& data)
+bool InplaceMultiChannelMedianFilter<T>::updateInplace(std::vector<T>& data)
 {
-  return update(data, data);
+  return this->update(data, data);
 }
 
 

--- a/include/filters/transfer_function.h
+++ b/include/filters/transfer_function.h
@@ -71,7 +71,7 @@ namespace filters
 */
 /***************************************************/
 template <typename T>
-class SingleChannelTransferFunctionFilter: public filters::FilterBase <T>
+class SingleChannelTransferFunctionFilter: public filters::InplaceFilterBase <T>
 {
 public:
   /**
@@ -222,7 +222,7 @@ bool SingleChannelTransferFunctionFilter<T>::update(const T  & data_in, T & data
 /***************************************************/
 
 template <typename T>
-class MultiChannelTransferFunctionFilter: public filters::MultiChannelFilterBase <T>
+class MultiChannelTransferFunctionFilter: public filters::InplaceMultiChannelFilterBase <T>
 {
 public:
   /**

--- a/include/filters/transfer_function.h
+++ b/include/filters/transfer_function.h
@@ -71,7 +71,7 @@ namespace filters
 */
 /***************************************************/
 template <typename T>
-class SingleChannelTransferFunctionFilter: public filters::InplaceFilterBase <T>
+class SingleChannelTransferFunctionFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
 {
 public:
   /**
@@ -94,6 +94,7 @@ public:
    * \param data_out vector<T> with number_of_channels elements
    */
   virtual bool update(const T & data_in, T& data_out) ;
+  bool update(T& data) override;
 
 
 
@@ -192,6 +193,12 @@ bool SingleChannelTransferFunctionFilter<T>::update(const T  & data_in, T & data
   return true;
 };
 
+template<typename T>
+bool SingleChannelTransferFunctionFilter<T>::update(T& data)
+{
+  return this->update(data, data);
+}
+
 
 
 /***************************************************/
@@ -222,7 +229,7 @@ bool SingleChannelTransferFunctionFilter<T>::update(const T  & data_in, T & data
 /***************************************************/
 
 template <typename T>
-class MultiChannelTransferFunctionFilter: public filters::InplaceMultiChannelFilterBase <T>
+class MultiChannelTransferFunctionFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
 {
 public:
   /**
@@ -245,6 +252,7 @@ public:
    * \param data_out vector<T> with number_of_channels elements
    */
   virtual bool update(const std::vector<T> & data_in, std::vector<T>& data_out) ;
+  bool update(std::vector<T>& data) override;
 
 
 
@@ -347,6 +355,12 @@ bool MultiChannelTransferFunctionFilter<T>::update(const std::vector<T>  & data_
   output_buffer_->push_front(data_out);
   return true;
 };
+
+template<typename T>
+bool MultiChannelTransferFunctionFilter<T>::update(std::vector<T>& data)
+{
+  return this->update(data, data);
+}
 
 }
 

--- a/include/filters/transfer_function.h
+++ b/include/filters/transfer_function.h
@@ -71,7 +71,7 @@ namespace filters
 */
 /***************************************************/
 template <typename T>
-class SingleChannelTransferFunctionFilter: public filters::FilterBase<T>, public filters::InplaceFilterBase<T>
+class SingleChannelTransferFunctionFilter: public filters::FilterBase<T>
 {
 public:
   /**
@@ -94,7 +94,6 @@ public:
    * \param data_out vector<T> with number_of_channels elements
    */
   virtual bool update(const T & data_in, T& data_out) ;
-  bool update(T& data) override;
 
 
 
@@ -108,6 +107,12 @@ protected:
   std::vector<double> a_;   //Transfer functon coefficients (output).
   std::vector<double> b_;   //Transfer functon coefficients (input).
 
+};
+
+template <typename T>
+class InplaceSingleChannelTransferFunctionFilter: public SingleChannelTransferFunctionFilter<T>, public InplaceFilterBase<T>
+{
+  bool updateInplace(T& data) override;
 };
 
 template <typename T>
@@ -194,7 +199,7 @@ bool SingleChannelTransferFunctionFilter<T>::update(const T  & data_in, T & data
 };
 
 template<typename T>
-bool SingleChannelTransferFunctionFilter<T>::update(T& data)
+bool InplaceSingleChannelTransferFunctionFilter<T>::updateInplace(T& data)
 {
   return this->update(data, data);
 }
@@ -229,7 +234,7 @@ bool SingleChannelTransferFunctionFilter<T>::update(T& data)
 /***************************************************/
 
 template <typename T>
-class MultiChannelTransferFunctionFilter: public filters::MultiChannelFilterBase<T>, public filters::InplaceMultiChannelFilterBase<T>
+class MultiChannelTransferFunctionFilter: public filters::MultiChannelFilterBase<T>
 {
 public:
   /**
@@ -252,7 +257,6 @@ public:
    * \param data_out vector<T> with number_of_channels elements
    */
   virtual bool update(const std::vector<T> & data_in, std::vector<T>& data_out) ;
-  bool update(std::vector<T>& data) override;
 
 
 
@@ -266,6 +270,12 @@ protected:
   std::vector<double> a_;   //Transfer functon coefficients (output).
   std::vector<double> b_;   //Transfer functon coefficients (input).
 
+};
+
+template <typename T>
+class InplaceMultiChannelTransferFunctionFilter: public MultiChannelTransferFunctionFilter<T>, public InplaceMultiChannelFilterBase<T>
+{
+  bool updateInplace(std::vector<T>& data) override;
 };
 
 template <typename T>
@@ -357,11 +367,11 @@ bool MultiChannelTransferFunctionFilter<T>::update(const std::vector<T>  & data_
 };
 
 template<typename T>
-bool MultiChannelTransferFunctionFilter<T>::update(std::vector<T>& data)
+bool InplaceMultiChannelTransferFunctionFilter<T>::updateInplace(std::vector<T>& data)
 {
   return this->update(data, data);
 }
 
 }
 
-#endif //#ifndef FILTERS_TRAjNSFER_FUNCTION_H_
+#endif //#ifndef FILTERS_TRANSFER_FUNCTION_H_

--- a/src/increment.cpp
+++ b/src/increment.cpp
@@ -33,5 +33,7 @@
 
 
 PLUGINLIB_EXPORT_CLASS(filters::IncrementFilter<int>, filters::FilterBase<int>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceIncrementFilter<int>, filters::FilterBase<int>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelIncrementFilter<int>, filters::MultiChannelFilterBase<int>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMultiChannelIncrementFilter<int>, filters::MultiChannelFilterBase<int>)
 

--- a/src/mean.cpp
+++ b/src/mean.cpp
@@ -33,7 +33,11 @@
 
 
 PLUGINLIB_EXPORT_CLASS(filters::MeanFilter<double>, filters::FilterBase<double>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMeanFilter<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::MeanFilter<float>, filters::FilterBase<float>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMeanFilter<float>, filters::FilterBase<float>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelMeanFilter<double>, filters::MultiChannelFilterBase<double>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMultiChannelMeanFilter<double>, filters::MultiChannelFilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelMeanFilter<float>, filters::MultiChannelFilterBase<float>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMultiChannelMeanFilter<float>, filters::MultiChannelFilterBase<float>)
 

--- a/src/median.cpp
+++ b/src/median.cpp
@@ -34,11 +34,15 @@
 
 //Double precision
 PLUGINLIB_EXPORT_CLASS(filters::MedianFilter<double>,filters::FilterBase<double>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMedianFilter<double>,filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelMedianFilter<double>,filters::MultiChannelFilterBase<double>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMultiChannelMedianFilter<double>,filters::MultiChannelFilterBase<double>)
 
 //Float precision
 PLUGINLIB_EXPORT_CLASS(filters::MedianFilter<float>,filters::FilterBase<float>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMedianFilter<float>,filters::FilterBase<float>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelMedianFilter<float>,filters::MultiChannelFilterBase<float>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMultiChannelMedianFilter<float>,filters::MultiChannelFilterBase<float>)
 
 
 

--- a/src/transfer_function.cpp
+++ b/src/transfer_function.cpp
@@ -31,5 +31,7 @@
 #include "pluginlib/class_list_macros.h"
 
 PLUGINLIB_EXPORT_CLASS(filters::SingleChannelTransferFunctionFilter<double>, filters::FilterBase<double>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceSingleChannelTransferFunctionFilter<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelTransferFunctionFilter<double>, filters::MultiChannelFilterBase<double>)
+PLUGINLIB_EXPORT_CLASS(filters::InplaceMultiChannelTransferFunctionFilter<double>, filters::MultiChannelFilterBase<double>)
 

--- a/test/test_mean.cpp
+++ b/test/test_mean.cpp
@@ -28,17 +28,15 @@
  */
 
 #include <gtest/gtest.h>
-#include <sys/time.h>
+#include <ctime>
+#include <cstdlib>
 #include "filters/mean.h"
 
 using namespace filters ;
 
 void seed_rand()
 {
-  //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -46,9 +44,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 

--- a/test/test_median.cpp
+++ b/test/test_median.cpp
@@ -28,18 +28,15 @@
  */
 
 #include <gtest/gtest.h>
-#include <sys/time.h>
-
+#include <ctime>
+#include <cstdlib>
 #include "filters/median.h"
 
 using namespace filters ;
 
 void seed_rand()
 {
-  //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -47,9 +44,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 

--- a/test/test_params.cpp
+++ b/test/test_params.cpp
@@ -28,7 +28,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <sys/time.h>
 #include "filters/param_test.h"
 
 using namespace filters ;

--- a/test/test_realtime_circular_buffer.cpp
+++ b/test/test_realtime_circular_buffer.cpp
@@ -28,8 +28,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <sys/time.h>
-
+#include <ctime>
+#include <cstdlib>
 #include <vector>
 #include "filters/realtime_circular_buffer.h"
 
@@ -37,10 +37,7 @@ using namespace filters ;
 
 void seed_rand()
 {
-  //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -48,9 +45,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 

--- a/test/test_transfer_function.cpp
+++ b/test/test_transfer_function.cpp
@@ -29,7 +29,6 @@
 
 #include <ros/ros.h>
 #include <gtest/gtest.h>
-#include <sys/time.h>
 #include <vector>
 #include "filters/transfer_function.h"
 


### PR DESCRIPTION
Solves #27.

I'll add tests later, but comments on the design are already welcome.

This changes both API and ABI of the defined filters (median, mean, increment, transfer_function), but as they are libraries nobody should link to, I think it could be doable. If this kind of breaks is not acceptable, there is a workaround solution - creating new filters (but I don't like this solution as it'd create another set of filters which differ only in the "flag" that they are inplace).

I also updated the filter_chain update functions so that they automatically detect inplace functions and call their inplace update methods whenever possible.