### PR TITLE
narrow down required boost dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,13 +18,13 @@
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>rostest</build_depend>
-  <build_depend>boost</build_depend>
+  <build_depend>libboost-dev</build_depend>
 
   <run_depend>roslib</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
-  <run_depend>boost</run_depend>
+  <run_depend>libboost-dev</run_depend>
 
 
   <export>


### PR DESCRIPTION
In an [ongoing effort](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.