### PR TITLE
Marking free functions inline

### DIFF
--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -44,7 +44,7 @@ namespace filters
 namespace impl
 {
 
-std::string normalize_param_prefix(std::string prefix)
+inline std::string normalize_param_prefix(std::string prefix)
 {
   if (!prefix.empty()) {
     if ('.' != prefix.back()) {

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -59,7 +59,7 @@ struct FoundFilter
 /**
  * \brief Read params and figure out what filters to load
  */
-bool
+inline bool
 load_chain_config(
   const std::string & param_prefix,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,


### PR DESCRIPTION
per #42
Fix proposed by @SteveMacenski.

## Problem 

The free functions in [filter_base.hpp](https://github.com/ros/filters/blob/ros2/include/filters/filter_base.hpp) and [filter_chain.hpp](https://github.com/ros/filters/blob/ros2/include/filters/filter_chain.hpp) get defined multiple times when these files are included in multiple source files in a library/executable. 

Example of [CMakeList.txt](https://github.com/ANYbotics/grid_map/blob/6e3305664854b27946ea0921b022e327a6c4d0d5/grid_map_filters/CMakeLists.txt#L49-L66) file, example of [linker error](https://app.circleci.com/pipelines/github/ANYbotics/grid_map/171/workflows/05dff0bf-7625-4d92-94b6-9b015704a64e/jobs/178).

The free functions were introduced in the ROS2 port in #32.

## Potential resolution

* Marking the free functions inline

Signed-off-by: Marwan Taher <marokhaled99@gmail.com>