### PR TITLE
Add include export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,5 +165,5 @@ install(DIRECTORY include/
 
 # Install pluginlib xml
 pluginlib_export_plugin_description_file(filters "default_plugins.xml")
-
+ament_export_include_directories(include)
 ament_package()


### PR DESCRIPTION
Hi,

It is necessary to add 

```
ament_export_include_directories(include)
```

in order to find the header of this package from others.

Hope it helps!!

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>