### PR TITLE
Minor cmake fix and inline function definitions added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,10 @@ find_package(Boost REQUIRED)
 
 add_library(real_time_circular_buffer INTERFACE)
 target_include_directories(real_time_circular_buffer INTERFACE
-  include
-  ${Boost_INCLUDE_DIRS})
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
+    $<INSTALL_INTERFACE:include>
+)
 
 # Plugins
 add_library(mean SHARED src/mean.cpp)
@@ -153,15 +155,19 @@ endif()
 
 # Install libraries
 install(
-  TARGETS mean increment median transfer_function
+  TARGETS mean increment median transfer_function real_time_circular_buffer
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
-
 # Install headers
 install(DIRECTORY include/
   DESTINATION include)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(pluginlib rclcpp)
 
 # Install pluginlib xml
 pluginlib_export_plugin_description_file(filters "default_plugins.xml")

--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -40,11 +40,10 @@
 
 namespace filters
 {
-
 namespace impl
 {
 
-std::string normalize_param_prefix(std::string prefix)
+inline std::string normalize_param_prefix(std::string prefix)
 {
   if (!prefix.empty()) {
     if ('.' != prefix.back()) {

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -59,7 +59,7 @@ struct FoundFilter
 /**
  * \brief Read params and figure out what filters to load
  */
-bool
+inline bool
 load_chain_config(
   const std::string & param_prefix,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,


### PR DESCRIPTION
The cmake has been configure to work with `--symlink-install` and
there was an error when finding boost header files for `real_time_circular_buffer`.

A couple functions inside `filter_base.hpp` and `filter_chain.hpp`
were declared inline to prevent multiple definitions errors.

Addresses issue [PR #42](https://github.com/ros/filters/issues/42) 