### PR TITLE
Remove lib/lib prefix from plugin library names

### DIFF
--- a/default_plugins.xml
+++ b/default_plugins.xml
@@ -1,5 +1,5 @@
 <class_libraries>
-  <library path="lib/libmedian">
+  <library path="median">
     <class name="filters/MultiChannelMedianFilterDouble" type="filters::MultiChannelMedianFilter&lt;double&gt;"
 	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
       <description>
@@ -25,7 +25,7 @@
       </description>
     </class>
   </library>
-  <library path="lib/libmean">
+  <library path="mean">
     <class name="filters/MeanFilterDouble" type="filters::MeanFilter&lt;double&gt;"
 	    base_class_type="filters::FilterBase&lt;double&gt;">
       <description>
@@ -51,7 +51,7 @@
       </description>
     </class>
   </library>
-  <library path="lib/libincrement">
+  <library path="increment">
     <class name="filters/IncrementFilterInt" type="filters::IncrementFilter&lt;int&gt;"
 	    base_class_type="filters::FilterBase&lt;int&gt;">
       <description>
@@ -65,7 +65,7 @@
       </description>
     </class>
   </library>
-  <library path="lib/libtransfer_function">
+  <library path="transfer_function">
     <class name="filters/MultiChannelTransferFunctionFilterDouble" type="filters::MultiChannelTransferFunctionFilter&lt;double&gt;"
 	    base_class_type="filters::MultiChannelFilterBase&lt;double&gt;">
       <description>


### PR DESCRIPTION
Otherwise pluginlib doesn't find the libraries.

Here's the error message that pluginlib was giving when laser_filters tried to load the MultiChannelMeanFilterFloat
```
1: [FATAL] [1625352531.577679387] [array_filter_chain]: Could not load library for filters/MultiChannelMeanFi
lterFloat: Could not find library corresponding to plugin filters/MultiChannelMeanFilterFloat. Make sure the 
plugin description XML file has the correct name of the library and that the library actually exists.
```

It also gave the warning:
```
[1625352466.389794925] [pluginlib.ClassLoader]: 
given plugin name 'lib/libmean' should be '/libmean' for better portability
```

But after changing the library name to "libmean", it gave the error:
```
1: [WARN] [1625356903.024168751] [pluginlib.ClassLoader]: given plugin name 'libmean' should be 'mean' for better portability
```

So it seems that the library should just be called "mean". I've also updated the other library names accordingly. After this change laser_filters is able to load the MultiChannelMeanFilterFloat.
