### PR TITLE
Change function signature to use pointer instead of array.

### DIFF
--- a/include/filters/median.hpp
+++ b/include/filters/median.hpp
@@ -62,7 +62,7 @@ namespace filters
   Series: Prentice-Hall Series in Automatic Computation
   ---------------------------------------------------------------------------*/
 template<typename elem_type>
-elem_type kth_smallest(elem_type a[], int n, int k)
+elem_type kth_smallest(elem_type * a, int n, int k)
 {
   int i, j, l, m;
   elem_type x;
@@ -86,7 +86,7 @@ elem_type kth_smallest(elem_type a[], int n, int k)
 }
 
 template<typename elem_type>
-elem_type median(elem_type a[], int n)
+elem_type median(elem_type * a, int n)
 {
   return kth_smallest(a, n, (((n) & 1) ? ((n) / 2) : (((n) / 2) - 1)));
 }


### PR DESCRIPTION
This really has no downstream consequence, but makes it so that
rosdoc2 can successfully generate documentation for all of this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>