### PR TITLE
Give access to FilterChain list of loaded filters

### DIFF
--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -232,8 +232,9 @@ public:
       auto p(loader_.createUnmanagedInstance(config[i]["type"]));
       if (p == nullptr)
         return false;
-      result = result &&  p->configure(config[i]);    
-      reference_pointers_.push_back(std::shared_ptr<filters::FilterBase<T>>(p));
+			std::shared_ptr<filters::FilterBase<T>> ptr(p);
+      result = result &&  ptr->configure(config[i]);    
+      reference_pointers_.push_back(ptr);
       std::string type = config[i]["type"];
       std::string name = config[i]["name"];
       ROS_DEBUG("%s: Configured %s:%s filter at %p\n", filter_ns.c_str(), type.c_str(),
@@ -474,8 +475,9 @@ public:
       auto p(loader_.createUnmanagedInstance(config[i]["type"]));
       if (p == nullptr)
         return false;
-      result = result &&  p->configure(size, config[i]);    
-      reference_pointers_.push_back(std::shared_ptr<filters::MultiChannelFilterBase<T>>(p));
+			std::shared_ptr<filters::MultiChannelFilterBase<T>> ptr(p);
+      result = result &&  ptr->configure(size, config[i]);    
+      reference_pointers_.push_back(ptr);
       std::string type = config[i]["type"];
       std::string name = config[i]["name"];
       ROS_DEBUG("Configured %s:%s filter at %p\n", type.c_str(),

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -229,6 +229,9 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
+      // The unmanaged instance created here is later passed to std::shared_ptr
+      // to handle its lifetime (this is done because pluginlib does not support
+      // creating std::shared_ptr pointers).
       auto p(loader_.createUnmanagedInstance(config[i]["type"]));
       if (p == nullptr)
         return false;
@@ -248,7 +251,9 @@ public:
     return result;
   };
 
-  const std::vector<std::shared_ptr<filters::FilterBase<T>>>& getFilters() const
+  /** \brief Return a copy of the vector of loaded filters (the pointers point
+   * to the actual filters used by the chain). */
+  std::vector<std::shared_ptr<filters::FilterBase<T>>> getFilters() const
   {
     return reference_pointers_;
   }
@@ -472,6 +477,9 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
+      // The unmanaged instance created here is later passed to std::shared_ptr
+      // to handle its lifetime (this is done because pluginlib does not support
+      // creating std::shared_ptr pointers).
       auto p(loader_.createUnmanagedInstance(config[i]["type"]));
       if (p == nullptr)
         return false;
@@ -491,7 +499,9 @@ public:
     return result;
   };
 
-  const std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T>>>& getFilters() const
+  /** \brief Return a copy of the vector of loaded filters (the pointers point
+   * to the actual filters used by the chain). */
+  std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T>>> getFilters() const
   {
     return reference_pointers_;
   }

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -33,9 +33,9 @@
 #include "ros/ros.h"
 #include "filters/filter_base.hpp"
 #include <pluginlib/class_loader.h>
+#include <memory>
 #include <sstream>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 namespace filters
 {
@@ -229,15 +229,15 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
-      boost::shared_ptr<filters::FilterBase<T> > p(loader_.createInstance(config[i]["type"]));
-      if (p.get() == NULL)
+      auto p(loader_.createUnmanagedInstance(config[i]["type"]));
+      if (p == nullptr)
         return false;
-      result = result &&  p.get()->configure(config[i]);    
-      reference_pointers_.push_back(p);
+      result = result &&  p->configure(config[i]);    
+      reference_pointers_.push_back(std::shared_ptr<filters::FilterBase<T>>(p));
       std::string type = config[i]["type"];
       std::string name = config[i]["name"];
       ROS_DEBUG("%s: Configured %s:%s filter at %p\n", filter_ns.c_str(), type.c_str(),
-                name.c_str(),  p.get());
+                name.c_str(),  p);
     }
     
     if (result == true)
@@ -247,9 +247,14 @@ public:
     return result;
   };
 
+	const std::vector<std::shared_ptr<filters::FilterBase<T>>>& getFilters() const
+	{
+		return reference_pointers_;
+	}
+
 private:
 
-  std::vector<boost::shared_ptr<filters::FilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
+  std::vector<std::shared_ptr<filters::FilterBase<T>>> reference_pointers_;   ///<! A vector of pointers to currently constructed filters
 
   T buffer0_; ///<! A temporary intermediate buffer
   T buffer1_; ///<! A temporary intermediate buffer
@@ -466,15 +471,15 @@ public:
        
     for (int i = 0; i < config.size(); ++i)
     {
-      boost::shared_ptr<filters::MultiChannelFilterBase<T> > p(loader_.createInstance(config[i]["type"]));
-      if (p.get() == NULL)
+      auto p(loader_.createUnmanagedInstance(config[i]["type"]));
+      if (p == nullptr)
         return false;
-      result = result &&  p.get()->configure(size, config[i]);    
-      reference_pointers_.push_back(p);
+      result = result &&  p->configure(size, config[i]);    
+      reference_pointers_.push_back(std::shared_ptr<filters::MultiChannelFilterBase<T>>(p));
       std::string type = config[i]["type"];
       std::string name = config[i]["name"];
       ROS_DEBUG("Configured %s:%s filter at %p\n", type.c_str(),
-                name.c_str(),  p.get());
+                name.c_str(),  p);
     }
     
     if (result == true)
@@ -484,9 +489,14 @@ public:
     return result;
   };
 
+	const std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T>>>& getFilters() const
+	{
+		return reference_pointers_;
+	}
+
 private:
 
-  std::vector<boost::shared_ptr<filters::MultiChannelFilterBase<T> > > reference_pointers_;   ///<! A vector of pointers to currently constructed filters
+  std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T>>> reference_pointers_;   ///<! A vector of pointers to currently constructed filters
 
   std::vector<T> buffer0_; ///<! A temporary intermediate buffer
   std::vector<T> buffer1_; ///<! A temporary intermediate buffer

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -232,7 +232,7 @@ public:
       auto p(loader_.createUnmanagedInstance(config[i]["type"]));
       if (p == nullptr)
         return false;
-			std::shared_ptr<filters::FilterBase<T>> ptr(p);
+      std::shared_ptr<filters::FilterBase<T>> ptr(p);
       result = result &&  ptr->configure(config[i]);    
       reference_pointers_.push_back(ptr);
       std::string type = config[i]["type"];
@@ -248,10 +248,10 @@ public:
     return result;
   };
 
-	const std::vector<std::shared_ptr<filters::FilterBase<T>>>& getFilters() const
-	{
-		return reference_pointers_;
-	}
+  const std::vector<std::shared_ptr<filters::FilterBase<T>>>& getFilters() const
+  {
+    return reference_pointers_;
+  }
 
 private:
 
@@ -475,7 +475,7 @@ public:
       auto p(loader_.createUnmanagedInstance(config[i]["type"]));
       if (p == nullptr)
         return false;
-			std::shared_ptr<filters::MultiChannelFilterBase<T>> ptr(p);
+      std::shared_ptr<filters::MultiChannelFilterBase<T>> ptr(p);
       result = result &&  ptr->configure(size, config[i]);    
       reference_pointers_.push_back(ptr);
       std::string type = config[i]["type"];
@@ -491,10 +491,10 @@ public:
     return result;
   };
 
-	const std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T>>>& getFilters() const
-	{
-		return reference_pointers_;
-	}
+  const std::vector<std::shared_ptr<filters::MultiChannelFilterBase<T>>>& getFilters() const
+  {
+    return reference_pointers_;
+  }
 
 private:
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -114,19 +114,19 @@ TEST(MultiChannelFilterChain, TwoFilters){
 TEST(MultiChannelFilterChain, GetFilters){
   filters::MultiChannelFilterChain<double> chain("double");
 
-	EXPECT_EQ(0u, chain.getFilters().size());
-	
+  EXPECT_EQ(0u, chain.getFilters().size());
+  
   EXPECT_TRUE(chain.configure(5, "TwoFilters"));
-	
-	ASSERT_EQ(2u, chain.getFilters().size());
-	EXPECT_EQ("median_test_unique", chain.getFilters()[0]->getName());
-	EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[0]->getType());
-	EXPECT_EQ("median_test2", chain.getFilters()[1]->getName());
-	EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[1]->getType());
-	
+  
+  ASSERT_EQ(2u, chain.getFilters().size());
+  EXPECT_EQ("median_test_unique", chain.getFilters()[0]->getName());
+  EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[0]->getType());
+  EXPECT_EQ("median_test2", chain.getFilters()[1]->getName());
+  EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[1]->getType());
+  
   chain.clear();
-
-	EXPECT_EQ(0u, chain.getFilters().size());
+  
+  EXPECT_EQ(0u, chain.getFilters().size());
 }
 
 
@@ -207,19 +207,19 @@ TEST(FilterChain, ReconfiguringChain){
 TEST(FilterChain, GetFilters){
   filters::FilterChain<int> chain("int");
 
-	EXPECT_EQ(0u, chain.getFilters().size());
-	
+  EXPECT_EQ(0u, chain.getFilters().size());
+  
   EXPECT_TRUE(chain.configure("TwoIncrements"));
 
-	ASSERT_EQ(2u, chain.getFilters().size());
-	EXPECT_EQ("increment1", chain.getFilters()[0]->getName());
-	EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[0]->getType());
-	EXPECT_EQ("increment2", chain.getFilters()[1]->getName());
-	EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[1]->getType());
-	
+  ASSERT_EQ(2u, chain.getFilters().size());
+  EXPECT_EQ("increment1", chain.getFilters()[0]->getName());
+  EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[0]->getType());
+  EXPECT_EQ("increment2", chain.getFilters()[1]->getName());
+  EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[1]->getType());
+  
   chain.clear();
 
-	EXPECT_EQ(0u, chain.getFilters().size());
+  EXPECT_EQ(0u, chain.getFilters().size());
   
 }
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -116,17 +116,36 @@ TEST(MultiChannelFilterChain, GetFilters){
 
   EXPECT_EQ(0u, chain.getFilters().size());
   
+  auto filtersBefore = chain.getFilters();
+  
   EXPECT_TRUE(chain.configure(5, "TwoFilters"));
+
+  auto filtersAfter = chain.getFilters();
   
   ASSERT_EQ(2u, chain.getFilters().size());
+  ASSERT_EQ(2u, filtersAfter.size());
+  EXPECT_EQ(0u, filtersBefore.size());  // Test that getFilters() returns a copy of the vector 
   EXPECT_EQ("median_test_unique", chain.getFilters()[0]->getName());
   EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[0]->getType());
   EXPECT_EQ("median_test2", chain.getFilters()[1]->getName());
   EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[1]->getType());
   
+  // Check that changing our copy of the list of filters does not change the
+  // filters handled by the chain.
+  filtersAfter.clear();
+  EXPECT_EQ(2u, chain.getFilters().size());
+  
+  filtersAfter = chain.getFilters();
+  
   chain.clear();
   
   EXPECT_EQ(0u, chain.getFilters().size());
+  ASSERT_EQ(2u, filtersAfter.size());
+
+  // Check that the filter pointers survive clearing the filter chain (if we
+  // hold a copy of the filter vector).
+  EXPECT_EQ("median_test_unique", filtersAfter[0]->getName());
+  EXPECT_EQ("median_test2", filtersAfter[1]->getName());
 }
 
 
@@ -201,26 +220,43 @@ TEST(FilterChain, ReconfiguringChain){
   EXPECT_TRUE(chain.update(v1, v1a));
   EXPECT_EQ(3, v1a);
   chain.clear();
-  
 }
 
 TEST(FilterChain, GetFilters){
   filters::FilterChain<int> chain("int");
 
   EXPECT_EQ(0u, chain.getFilters().size());
+
+  auto filtersBefore = chain.getFilters();
   
   EXPECT_TRUE(chain.configure("TwoIncrements"));
 
+  auto filtersAfter = chain.getFilters();
+
   ASSERT_EQ(2u, chain.getFilters().size());
+  ASSERT_EQ(2u, filtersAfter.size());
+  EXPECT_EQ(0u, filtersBefore.size());  // Test that getFilters() returns a copy of the vector
   EXPECT_EQ("increment1", chain.getFilters()[0]->getName());
   EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[0]->getType());
   EXPECT_EQ("increment2", chain.getFilters()[1]->getName());
   EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[1]->getType());
-  
+
+  // Check that changing our copy of the list of filters does not change the
+  // filters handled by the chain.
+  filtersAfter.clear();
+  EXPECT_EQ(2u, chain.getFilters().size());
+
+  filtersAfter = chain.getFilters();
+
   chain.clear();
 
   EXPECT_EQ(0u, chain.getFilters().size());
-  
+  ASSERT_EQ(2u, filtersAfter.size());
+
+  // Check that the filter pointers survive clearing the filter chain (if we
+  // hold a copy of the filter vector).
+  EXPECT_EQ("increment1", filtersAfter[0]->getName());
+  EXPECT_EQ("increment2", filtersAfter[1]->getName());
 }
 
 TEST(FilterChain, ThreeIncrementChains){

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -111,6 +111,24 @@ TEST(MultiChannelFilterChain, TwoFilters){
   }
 }
 
+TEST(MultiChannelFilterChain, GetFilters){
+  filters::MultiChannelFilterChain<double> chain("double");
+
+	EXPECT_EQ(0u, chain.getFilters().size());
+	
+  EXPECT_TRUE(chain.configure(5, "TwoFilters"));
+	
+	ASSERT_EQ(2u, chain.getFilters().size());
+	EXPECT_EQ("median_test_unique", chain.getFilters()[0]->getName());
+	EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[0]->getType());
+	EXPECT_EQ("median_test2", chain.getFilters()[1]->getName());
+	EXPECT_EQ("filters/MultiChannelMedianFilterDouble", chain.getFilters()[1]->getType());
+	
+  chain.clear();
+
+	EXPECT_EQ(0u, chain.getFilters().size());
+}
+
 
 TEST(MultiChannelFilterChain, TransferFunction){
   double epsilon = 1e-4;
@@ -183,6 +201,25 @@ TEST(FilterChain, ReconfiguringChain){
   EXPECT_TRUE(chain.update(v1, v1a));
   EXPECT_EQ(3, v1a);
   chain.clear();
+  
+}
+
+TEST(FilterChain, GetFilters){
+  filters::FilterChain<int> chain("int");
+
+	EXPECT_EQ(0u, chain.getFilters().size());
+	
+  EXPECT_TRUE(chain.configure("TwoIncrements"));
+
+	ASSERT_EQ(2u, chain.getFilters().size());
+	EXPECT_EQ("increment1", chain.getFilters()[0]->getName());
+	EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[0]->getType());
+	EXPECT_EQ("increment2", chain.getFilters()[1]->getName());
+	EXPECT_EQ("filters/IncrementFilterInt", chain.getFilters()[1]->getType());
+	
+  chain.clear();
+
+	EXPECT_EQ(0u, chain.getFilters().size());
   
 }
 


### PR DESCRIPTION
This PR makes `FilterChain` members `reference_pointers_`, `buffer0_` and `buffer1_` protected instead of private. This helps writing custom filter chain implementations that e.g. need to access the list of loaded filters or that do updating in a different way and want to utilize the already existing buffer variables.

If making the buffers protected would seem undesirable, that part of the PR can be reverted. The buffers are really implementation-specific things and making them protected would just allow child classes to utilize them the same way `FilterChain` does. But I don't think it hurts exposing these, too (they're only used in the `update()` method and serve as cache variables with no meaning outside the method; moreover, the `update()` method wipes any content of the buffers when it is called, so even if the buffers contain some unexpected values, it should not break the working of the `update()` metod). The only thing that would hurt the operation of the chain would be asynchronous calls, but as `update()` isn't thread-safe at all even now, I wouldn't see that as a problem.