### PR TITLE
[ROS-O] remove obsolete register keyword

### DIFF
--- a/include/filters/median.hpp
+++ b/include/filters/median.hpp
@@ -46,7 +46,7 @@
  * Algorithm from N. Wirth's book, implementation by N. Devillard.
  * This code in public domain.
  */
-#define ELEM_SWAP(a,b) { register elem_type t=(a);(a)=(b);(b)=t; }
+#define ELEM_SWAP(a,b) { elem_type t=(a);(a)=(b);(b)=t; }
 
 namespace filters
 {
@@ -66,8 +66,8 @@ namespace filters
 template <typename elem_type>
 elem_type kth_smallest(elem_type a[], int n, int k)
 {
-  register int i,j,l,m ;
-  register elem_type x ;
+  int i,j,l,m ;
+  elem_type x ;
   l=0 ; m=n-1 ;
   while (l<m) {
     x=a[k] ;


### PR DESCRIPTION
it's forbidden in C++17 and never served a purpose here.

required for the ROS-O initiative.