### PR TITLE
[ROS-O] update pluginlib include names

### DIFF
--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -32,7 +32,7 @@
 
 #include "ros/ros.h"
 #include "filters/filter_base.hpp"
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <memory>
 #include <sstream>
 #include <vector>

--- a/src/increment.cpp
+++ b/src/increment.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/increment.hpp"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 
 

--- a/src/mean.cpp
+++ b/src/mean.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/mean.hpp"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 
 

--- a/src/median.cpp
+++ b/src/median.cpp
@@ -29,7 +29,7 @@
 
 
 #include "filters/median.hpp"
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 
 //Double precision

--- a/src/test_params.cpp
+++ b/src/test_params.cpp
@@ -29,7 +29,7 @@
 
 
 #include "filters/param_test.hpp"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(filters::ParamTest<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::ParamTest<int>, filters::FilterBase<int>)

--- a/src/transfer_function.cpp
+++ b/src/transfer_function.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "filters/transfer_function.hpp"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(filters::SingleChannelTransferFunctionFilter<double>, filters::FilterBase<double>)
 PLUGINLIB_EXPORT_CLASS(filters::MultiChannelTransferFunctionFilter<double>, filters::MultiChannelFilterBase<double>)


### PR DESCRIPTION
The non-hpp includes are deprecated since kinetic.