### PR TITLE
Export the right library names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,9 +204,8 @@ endif()
 # Install
 ##############################################################################
 
-# Export old-style CMake variables
+# Export old-style CMake variables for includes
 ament_export_include_directories("include/${PROJECT_NAME}")
-ament_export_libraries(${interface_targets} ${plugin_targets})
 
 # Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ target_link_libraries(realtime_circular_buffer
     Boost::boost
 )
 
+# filter_base is an INTERFACE library because it only has header files.
+# It is not compiled, but sets up the following properties for consumers
+# to link to a target.
+# For more info, see the CMake Wiki on INTERFACE targets.
+# https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries
 add_library(filter_base
   INTERFACE
     include/filters/filter_base.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ endif()
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
-ament_export_libraries(${PROJECT_NAME})
+ament_export_libraries(${interface_targets} ${plugin_targets})
 
 # Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Usage with ament_cmake
 
-Here is recommended approach on how to link `filters` to your project, using the `filter_base` target.
+Here is recommended approach on how to link `filters` to your project, using the `filters::realtime_circular_buffer` target.
 
 ```cmake
 find_package(filters CONFIG REQUIRED)
@@ -10,9 +10,21 @@ find_package(filters CONFIG REQUIRED)
 add_library(my_library)
 # Other library stuff here
 
-target_link_libraries(my_library PUBLIC filters::filter_base)
+target_link_libraries(my_library PUBLIC filters::realtime_circular_buffer)
 ```
 
-For more information, 
+For more information on using ament_cmake, 
 see the [ament_cmake](https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html)
 tutorial.
+
+Filters creates all of the following CMake targets, including:
+* filters::realtime_circular_buffer
+* filters::filter_chain
+* filters::mean
+* filters::params
+* filters::increment
+* filters::median
+* filters::transfer_function
+
+It is recommended to only link to the libraries needed.
+Linking to `filters::filter_base` pulls in all necessary libraries and include directories for targets with classes that extend `FilterBase`. This is useful if you are writing your own filter.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ add_library(my_library)
 target_link_libraries(my_library PUBLIC filters::filter_base)
 ```
 
-Do NOT use the `filters_LIBRARIES` anymore.
-
 For more information, 
 see the [ament_cmake](https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html)
 tutorial.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Filters
+
+## Usage with ament_cmake
+
+Here is recommended approach on how to link `filters` to your project, using the `filter_base` target.
+
+```cmake
+find_package(filters CONFIG REQUIRED)
+
+add_library(my_library)
+# Other library stuff here
+
+target_link_libraries(my_library PUBLIC filters::filter_base)
+```
+
+Do NOT use the `filters_LIBRARIES` anymore.
+
+For more information, 
+see the [ament_cmake](https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html)
+tutorial.


### PR DESCRIPTION
# Purpose

Follow up to #70, addressing the problem of exporting the library ${PROJECT_NAME}, when no such library target existed.

# Details

I tried continuing to use ament_export_libraries, but it just shouldn't be used.

Exports the bare library names that no longer exist:
`ament_export_libraries(${interface_targets} ${plugin_targets})`
Generates:
`set(_exported_libraries "realtime_circular_buffer;filter_base;filter_chain;mean;params;increment;median;transfer_function")
`
Error:
```
CMake Error at /home/ryan/Dev/ros2_ws/src/filters/install/filters/share/filters/cmake/ament_cmake_export_libraries-extras.cmake:48 (message):
  Package 'filters' exports the library 'realtime_circular_buffer' which
  couldn't be found
Call Stack (most recent call first):
  /home/ryan/Dev/ros2_ws/src/filters/install/filters/share/filters/cmake/filtersConfig.cmake:41 (include)
  CMakeLists.txt:7 (find_package)
```
Ok, so try to export the new names that prepend the project.
This tidbit exports the proper library names, but ament_export_libraries doesn't handle libraries with colons in the names.
```cmake
unset(_exported_libraries)
list(APPEND _exported_libraries ${interface_targets} ${plugin_targets})
list(TRANSFORM _exported_libraries PREPEND ${PROJECT_NAME}::)
ament_export_libraries(${_exported_libraries})
```
Generates: `set(_exported_library_names "filters::realtime_circular_buffer;filters::filter_base;filters::filter_chain;filters::mean;filters::params;filters::increment;filters::median;filters::transfer_function")`

But then has warnings in usage:
```
CMake Warning at /home/ryan/Dev/ros2_ws/src/filters/install/filters/share/filters/cmake/ament_cmake_export_libraries-extras.cmake:128 (message):
  Package 'filters' exports library 'filters' with LIBRARY_DIRS
  ';realtime_circular_buffer' which couldn't be found
Call Stack (most recent call first):
  /home/ryan/Dev/ros2_ws/src/filters/install/filters/share/filters/cmake/filtersConfig.cmake:41 (include)
  CMakeLists.txt:7 (find_package)
  ```
  
 Solution - remove it! It is my impression that ROS does not provide a good transitional mechanism for the old-style variables.
 
 Consumers MUST use either target_link_libraries with filters::realtime_circular_buffer or ament_target_dependencies(filters). 
 
# Logs

```
ryan@B650-970:~/Dev/ros2_ws/src/filters$ git checkout fix-export-libraries 
Branch 'fix-export-libraries' set up to track remote branch 'fix-export-libraries' from 'origin'.
Switched to a new branch 'fix-export-libraries'
ryan@B650-970:~/Dev/ros2_ws/src/filters$ . /opt/ros/rolling/setup.bash
ryan@B650-970:~/Dev/ros2_ws/src/filters$ colcon ubild
usage: colcon [-h] [--log-base LOG_BASE] [--log-level LOG_LEVEL] {build,extension-points,extensions,graph,info,list,metadata,mixin,test,test-result,version-check} ...
colcon: error: argument verb_name: invalid choice: 'ubild' (choose from 'build', 'extension-points', 'extensions', 'graph', 'info', 'list', 'metadata', 'mixin', 'test', 'test-result', 'version-check')
ryan@B650-970:~/Dev/ros2_ws/src/filters$ colcon build
[0.627s] WARNING:colcon.colcon_core.package_selection:Some selected packages are already built in one or more underlay workspaces:
	'filters' is in: /opt/ros/rolling
If a package in a merged underlay workspace is overridden and it installs headers, then all packages in the overlay must sort their include directories by workspace order. Failure to do so may result in build failures or undefined behavior at run time.
If the overridden package is used by another package in any underlay, then the overriding package in the overlay must be API and ABI compatible or undefined behavior at run time may occur.

If you understand the risks and want to override a package anyways, add the following to the command line:
	--allow-overriding filters

This may be promoted to an error in a future release of colcon-override-check.
Starting >>> filters 
Finished <<< filters [8.91s]                     

Summary: 1 package finished [9.37s]

```

```
$ cat install/filters/share/filters/cmake/ament_cmake_export_libraries-extras.cmake 
# generated from ament_cmake_export_libraries/cmake/template/ament_cmake_export_libraries.cmake.in

set(_exported_libraries "realtime_circular_buffer;filter_base;filter_chain;mean;params;increment;median;transfer_function")
set(_exported_library_names "")
```