### PR TITLE
Add a virtual definition of configure() in MultiChannelFilterBase.

### DIFF
--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -277,6 +277,11 @@ public:
    */
   virtual ~MultiChannelFilterBase() = default;
 
+  virtual bool configure()
+  {
+    return true;
+  }
+
   /**
    * \brief Configure the filter from the parameter server
    * \param number_of_channels How many parallel channels the filter will process


### PR DESCRIPTION
Otherwise, modern gcc (13.2.0) complains that the method is "hidden":

hidden-method.cpp:37:16: warning: ‘virtual bool FilterBase::configure()’ was hidden [-Woverloaded-virtual=]
   37 |   virtual bool configure() = 0;
      |                ^~~~~~~~~
hidden-method.cpp:43:8: note:   by ‘bool MultiChannelFilterBase::configure(size_t, const std::string&, const std::string&, const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr&, const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr&)’
   43 |   bool configure(
      |        ^~~~~~~~~