### PR TITLE
Fix the RHEL-9 build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,10 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(Boost REQUIRED COMPONENTS headers)
+find_package(Boost QUIET COMPONENTS headers)
+if(NOT Boost_headers_FOUND)
+  find_package(Boost REQUIRED)
+endif()
 
 ##############################################################################
 # Build


### PR DESCRIPTION
The version of Boost there is old enough that it does not have the separate headers component.  In that case, fall back to just finding Boost.

This is essentially a follow-up to #70 to make this build on RHEL-9.  It should fix the failing build as seen in https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__filters__rhel_9_x86_64__binary/91/console