### PR TITLE
Clean up filter chain parameter loading

### DIFF
--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -75,21 +75,23 @@ inline bool auto_declare_string(
   rclcpp::ParameterValue param_value;
   try {
     param_value = node_params->declare_parameter(
-        param_desc.name, rclcpp::ParameterType::PARAMETER_STRING, param_desc);
+      param_desc.name, rclcpp::ParameterType::PARAMETER_STRING, param_desc);
   } catch (rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     rclcpp::Parameter param = node_params->get_parameter(param_name);
     param_value = param.get_parameter_value();
   } catch (rclcpp::exceptions::InvalidParametersException &) {
-    RCLCPP_ERROR(node_logger->get_logger(), "Tried to declare param with invalid name: %s",
-          param_name.c_str());
+    RCLCPP_ERROR(
+      node_logger->get_logger(), "Tried to declare param with invalid name: %s",
+      param_name.c_str());
     return false;
   }
 
   try {
     param_out = param_value.get<std::string>();
   } catch (rclcpp::exceptions::InvalidParameterTypeException &) {
-    RCLCPP_ERROR(node_logger->get_logger(), "Parameter %s of invalid type (must be a string)",
-          param_name.c_str());
+    RCLCPP_ERROR(
+      node_logger->get_logger(), "Parameter %s of invalid type (must be a string)",
+      param_name.c_str());
     return false;
   }
   return true;
@@ -125,17 +127,18 @@ load_chain_config(
     }
 
     std::string filter_name;
-    if(!auto_declare_string(node_logger, node_params, name_of_name_param, filter_name)) {
+    if (!auto_declare_string(node_logger, node_params, name_of_name_param, filter_name)) {
       return false;
     }
 
     std::string filter_type;
-    if(!auto_declare_string(node_logger, node_params, name_of_type_param, filter_type)) {
+    if (!auto_declare_string(node_logger, node_params, name_of_type_param, filter_type)) {
       return false;
     }
 
-    if (std::find_if(found_filters.begin(), found_filters.end(),
-      [&](const FoundFilter & f) {return  f.name == filter_name;}) != found_filters.end())
+    if (std::find_if(
+        found_filters.begin(), found_filters.end(),
+        [&](const FoundFilter & f) {return f.name == filter_name;}) != found_filters.end())
     {
       RCLCPP_FATAL(
         node_logger->get_logger(),

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -78,7 +78,7 @@ load_chain_config(
   const std::string & param_prefix,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,
   const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params,
-  std::vector<struct FoundFilter> & found_filters)
+  std::vector<struct FoundFilter> & found_filters, const bool read_only = true)
 {
   // TODO(sloretz) error if someone tries to do filter0
   const std::string norm_param_prefix = impl::normalize_param_prefix(param_prefix);
@@ -165,8 +165,8 @@ load_chain_config(
     // Redeclare 'name' and 'type' as read_only
     node_params->undeclare_parameter(name_desc.name);
     node_params->undeclare_parameter(type_desc.name);
-    name_desc.read_only = false;
-    type_desc.read_only = false;
+    name_desc.read_only = read_only;
+    type_desc.read_only = read_only;
     node_params->declare_parameter(
       name_desc.name, rclcpp::ParameterValue(found_filter.name), name_desc);
     node_params->declare_parameter(
@@ -255,7 +255,8 @@ public:
   bool configure(
     const std::string & param_prefix,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,
-    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params)
+    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params,
+    const bool read_only = true)
   {
     if (configured_) {
       RCLCPP_ERROR(logging_interface_->get_logger(), "Filter chain is already configured");
@@ -266,7 +267,7 @@ public:
 
     std::vector<struct impl::FoundFilter> found_filters;
     if (!impl::load_chain_config(
-        param_prefix, logging_interface_, params_interface_, found_filters))
+        param_prefix, logging_interface_, params_interface_, found_filters, read_only))
     {
       // Assume load_chain_config() console logged something sensible
       return false;
@@ -404,7 +405,8 @@ public:
     size_t number_of_channels,
     const std::string & param_prefix,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,
-    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params)
+    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params,
+    const bool read_only = true)
   {
     if (configured_) {
       RCLCPP_ERROR(logging_interface_->get_logger(), "Filter chain is already configured");
@@ -415,7 +417,7 @@ public:
 
     std::vector<impl::FoundFilter> found_filters;
     if (!impl::load_chain_config(
-        param_prefix, logging_interface_, params_interface_, found_filters))
+        param_prefix, logging_interface_, params_interface_, found_filters, read_only))
     {
       // Assume load_chain_config() console logged something sensible
       return false;

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -31,8 +31,6 @@
 #define FILTERS__FILTER_CHAIN_HPP_
 
 #include <algorithm>
-#include <rcl_interfaces/msg/detail/parameter_descriptor__struct.hpp>
-#include <rclcpp/parameter_value.hpp>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -41,6 +39,7 @@
 #include "pluginlib/class_loader.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rcl_interfaces/msg/parameter_type.hpp"
+#include <rclcpp/parameter_value.hpp>
 #include "rclcpp/rclcpp.hpp"
 
 #include "filters/filter_base.hpp"
@@ -58,16 +57,42 @@ struct FoundFilter
   std::string param_prefix;
 };
 
+/**
+ * \brief Declare a string param of the given name. If it already exists, just get the value.
+ */
+inline bool auto_declare_string(
+  const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params,
+  const std::string & param_name,
+  std::string & param_out)
+{
+  rcl_interfaces::msg::ParameterDescriptor param_desc;
+  param_desc.name = param_name;
+  param_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  param_desc.read_only = true;
+  param_desc.dynamic_typing = false;
 
-inline rclcpp::Parameter auto_declare(
-  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & param_itf,
-  const rcl_interfaces::msg::ParameterDescriptor& param_desc) {
-  if (!param_itf->has_parameter(param_desc.name))
-  {
-    //param_itf->declare_parameter(param_desc.name, default_value);
-    param_itf->declare_parameter(param_desc.name, rclcpp::ParameterValue(), param_desc);
+  rclcpp::ParameterValue param_value;
+  try {
+    param_value = node_params->declare_parameter(
+        param_desc.name, rclcpp::ParameterType::PARAMETER_STRING, param_desc);
+  } catch (rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+    rclcpp::Parameter param = node_params->get_parameter(param_name);
+    param_value = param.get_parameter_value();
+  } catch (rclcpp::exceptions::InvalidParametersException &) {
+    RCLCPP_ERROR(node_logger->get_logger(), "Tried to declare param with invalid name: %s",
+          param_name.c_str());
+    return false;
   }
-  return param_itf->get_parameter(param_desc.name);
+
+  try {
+    param_out = param_value.get<std::string>();
+  } catch (rclcpp::exceptions::InvalidParameterTypeException &) {
+    RCLCPP_ERROR(node_logger->get_logger(), "Parameter %s of invalid type (must be a string)",
+          param_name.c_str());
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -78,100 +103,56 @@ load_chain_config(
   const std::string & param_prefix,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,
   const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params,
-  std::vector<struct FoundFilter> & found_filters, const bool read_only = true)
+  std::vector<struct FoundFilter> & found_filters)
 {
   // TODO(sloretz) error if someone tries to do filter0
   const std::string norm_param_prefix = impl::normalize_param_prefix(param_prefix);
 
+  const auto & param_overrides = node_params->get_parameter_overrides();
+
   // Read parameters for filter1..filterN
-  for (size_t filter_num = 1; filter_num > found_filters.size(); ++filter_num) {
+  for (size_t filter_num = 1; true; ++filter_num) {
     // Parameters in chain are prefixed with 'filterN.'
-    const std::string filter_n = "filter" + std::to_string(filter_num);
+    const std::string name_of_name_param = norm_param_prefix + "filter" +
+      std::to_string(filter_num) + ".name";
+    const std::string name_of_type_param = norm_param_prefix + "filter" +
+      std::to_string(filter_num) + ".type";
+    const std::string name_of_param_prefix_param = norm_param_prefix + "filter" +
+      std::to_string(filter_num) + ".params";
 
-    // Declare filterN.name and filterN.type
-    rcl_interfaces::msg::ParameterDescriptor name_desc;
-    name_desc.name = norm_param_prefix + filter_n + ".name";
-    name_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-    name_desc.read_only = false;
-    // Must be dynamically typed because later we undeclare it and redeclare
-    // it read-only, but statically typed params cannot be undeclared.
-    name_desc.dynamic_typing = true;
-    rcl_interfaces::msg::ParameterDescriptor type_desc;
-    type_desc.name = norm_param_prefix + filter_n + ".type";
-    type_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-    type_desc.read_only = false;
-    // Must be dynamically typed because later we undeclare it and redeclare
-    // it read-only, but statically typed params cannot be undeclared.
-    type_desc.dynamic_typing = true;
-
-    rclcpp::Parameter param_name;
-    rclcpp::Parameter param_type;
-    param_name = auto_declare(node_params, name_desc);
-    param_type = auto_declare(node_params, type_desc);
-
-    const bool got_name = node_params->get_parameter(name_desc.name, param_name);
-    const bool got_type = node_params->get_parameter(type_desc.name, param_type);
-
-    if (!got_name && !got_type) {
-      // Reached end of chain
+    if (param_overrides.find(name_of_name_param) == param_overrides.end()) {
       break;
-    } else if (got_name != got_type) {
-      RCLCPP_FATAL(
-        node_logger->get_logger(),
-        "%s and %s are required", name_desc.name.c_str(), type_desc.name.c_str());
+    }
+
+    std::string filter_name;
+    if(!auto_declare_string(node_logger, node_params, name_of_name_param, filter_name)) {
       return false;
     }
 
-    // Make sure 'name' and 'type' are strings
-    if (rclcpp::PARAMETER_STRING != param_name.get_type()) {
-      RCLCPP_FATAL(
-        node_logger->get_logger(),
-        "%s must be a string", name_desc.name.c_str());
-      return false;
-    }
-    if (rclcpp::PARAMETER_STRING != param_type.get_type()) {
-      RCLCPP_FATAL(
-        node_logger->get_logger(),
-        "%s must be a string", type_desc.name.c_str());
+    std::string filter_type;
+    if(!auto_declare_string(node_logger, node_params, name_of_type_param, filter_type)) {
       return false;
     }
 
-    FoundFilter found_filter;
-    found_filter.name = param_name.get_parameter_value().get<std::string>();
-    found_filter.type = param_type.get_parameter_value().get<std::string>();
-
-    // Make sure 'name' is unique
-    for (const auto & filter : found_filters) {
-      if (found_filter.name == filter.name) {
-        RCLCPP_FATAL(
-          node_logger->get_logger(),
-          "A filter with the name %s already exists", filter.name.c_str());
-        return false;
-      }
+    if (std::find_if(found_filters.begin(), found_filters.end(),
+      [&](const FoundFilter & f) {return  f.name == filter_name;}) != found_filters.end())
+    {
+      RCLCPP_FATAL(
+        node_logger->get_logger(),
+        "A filter with the name %s already exists", filter_name.c_str());
+      return false;
     }
 
     // Make sure 'type' is formated as 'package_name/filtername'
-    if (1 != std::count(found_filter.type.cbegin(), found_filter.type.cend(), '/')) {
+    if (1 != std::count(filter_type.cbegin(), filter_type.cend(), '/')) {
       RCLCPP_FATAL(
         node_logger->get_logger(),
-        "%s must be of form <package_name>/<filter_name>", found_filter.type.c_str());
+        "%s must be of form <package_name>/<filter_name>", filter_type.c_str());
       return false;
     }
 
     // Seems ok; store it for now; it will be loaded further down.
-    found_filter.param_prefix = norm_param_prefix + filter_n + ".params";
-    found_filters.push_back(found_filter);
-
-    // Redeclare 'name' and 'type' as read_only
-    node_params->undeclare_parameter(name_desc.name);
-    node_params->undeclare_parameter(type_desc.name);
-    name_desc.read_only = read_only;
-    type_desc.read_only = read_only;
-    node_params->declare_parameter(
-      name_desc.name, rclcpp::ParameterValue(found_filter.name), name_desc);
-    node_params->declare_parameter(
-      type_desc.name, rclcpp::ParameterValue(found_filter.type), type_desc);
-  
+    found_filters.push_back({filter_name, filter_type, name_of_param_prefix_param});
   }
   return true;
 }
@@ -255,8 +236,7 @@ public:
   bool configure(
     const std::string & param_prefix,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,
-    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params,
-    const bool read_only = true)
+    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params)
   {
     if (configured_) {
       RCLCPP_ERROR(logging_interface_->get_logger(), "Filter chain is already configured");
@@ -267,7 +247,7 @@ public:
 
     std::vector<struct impl::FoundFilter> found_filters;
     if (!impl::load_chain_config(
-        param_prefix, logging_interface_, params_interface_, found_filters, read_only))
+        param_prefix, logging_interface_, params_interface_, found_filters))
     {
       // Assume load_chain_config() console logged something sensible
       return false;
@@ -405,8 +385,7 @@ public:
     size_t number_of_channels,
     const std::string & param_prefix,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logger,
-    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params,
-    const bool read_only = true)
+    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_params)
   {
     if (configured_) {
       RCLCPP_ERROR(logging_interface_->get_logger(), "Filter chain is already configured");
@@ -417,7 +396,7 @@ public:
 
     std::vector<impl::FoundFilter> found_filters;
     if (!impl::load_chain_config(
-        param_prefix, logging_interface_, params_interface_, found_filters, read_only))
+        param_prefix, logging_interface_, params_interface_, found_filters))
     {
       // Assume load_chain_config() console logged something sensible
       return false;

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -122,9 +122,11 @@ TEST_F(ChainTest, configuring) {
 TEST_F(ChainTest, ParallelChainConfiguring) {
   double epsilon = 1e-9;
   std::vector<rclcpp::Parameter> overrides;
-  overrides.emplace_back("ParallelChainMeanFilter.filter1.name",
+  overrides.emplace_back(
+    "ParallelChainMeanFilter.filter1.name",
     std::string("parallel_chain_test"));
-  overrides.emplace_back("ParallelChainMeanFilter.filter1.type",
+  overrides.emplace_back(
+    "ParallelChainMeanFilter.filter1.type",
     std::string("filters/MeanFilterFloat"));
   overrides.emplace_back("ParallelChainMeanFilter.filter1.params.number_of_observations", 5);
   auto node = make_node_with_params(overrides);
@@ -133,14 +135,14 @@ TEST_F(ChainTest, ParallelChainConfiguring) {
     std::make_shared<filters::FilterChain<float>>("float"),
     std::make_shared<filters::FilterChain<float>>("float")};
 
-  for(auto & chain : chains) {
+  for (auto & chain : chains) {
     ASSERT_TRUE(
-        chain->configure(
-            "ParallelChainMeanFilter", node->get_node_logging_interface(),
-            node->get_node_parameters_interface()));
+      chain->configure(
+        "ParallelChainMeanFilter", node->get_node_logging_interface(),
+        node->get_node_parameters_interface()));
   }
 
-  for(auto & chain : chains) {
+  for (auto & chain : chains) {
     float v1 = 1.;
     float v1a = 9.;
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -114,6 +114,44 @@ TEST_F(ChainTest, configuring) {
   EXPECT_NEAR(v1, v1a, epsilon);
 }
 
+/**
+ * In order to parallelize filtering, users may want to instantiate multiple filter chains using
+ * one set of parameters. In this case we need to not error out if the parameters have already
+ * beend declared by one of the other filter chain instances.
+ */
+TEST_F(ChainTest, ParallelChainConfiguring) {
+  double epsilon = 1e-9;
+  std::vector<rclcpp::Parameter> overrides;
+  overrides.emplace_back("ParallelChainMeanFilter.filter1.name",
+    std::string("parallel_chain_test"));
+  overrides.emplace_back("ParallelChainMeanFilter.filter1.type",
+    std::string("filters/MeanFilterFloat"));
+  overrides.emplace_back("ParallelChainMeanFilter.filter1.params.number_of_observations", 5);
+  auto node = make_node_with_params(overrides);
+
+  std::vector<std::shared_ptr<filters::FilterChain<float>>> chains {
+    std::make_shared<filters::FilterChain<float>>("float"),
+    std::make_shared<filters::FilterChain<float>>("float")};
+
+  for(auto & chain : chains) {
+    ASSERT_TRUE(
+        chain->configure(
+            "ParallelChainMeanFilter", node->get_node_logging_interface(),
+            node->get_node_parameters_interface()));
+  }
+
+  for(auto & chain : chains) {
+    float v1 = 1.;
+    float v1a = 9.;
+
+    EXPECT_TRUE(chain->update(v1, v1a));
+
+    chain->clear();
+
+    EXPECT_NEAR(v1, v1a, epsilon);
+  }
+}
+
 TEST_F(ChainTest, MisconfiguredNumberOfChannels) {
   filters::MultiChannelFilterChain<double> chain("double");
 


### PR DESCRIPTION
By looking at the parameter overrides, we can know how many filters are being configured without first declaring their parameters. This is cleaner than declaring them as dynamic, then checking them, then undeclaring them and redeclaring them as static.

Also makes filter chains work if their parameters have already been declared. This allows users to create multiple filter chains with the same parameters in order to parallelize their workload.

This incorporates and builds on the work by @ipa-dmo in https://github.com/ros/filters/pull/79