### PR TITLE
Add Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 ##############################################################################
 # Find dependencies


### PR DESCRIPTION
The package in this repo compiles shared libraries, but does not expose any symbol on Windows, so no library is actually generated on Windows.

On Linux and macOS, everything compiles fine with  `-DBUILD_SHARED_LIBS:BOOL=ON` as by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation works fine on Windows.