### PR TITLE
Handle dynamic reconfiguration of parameters

### DIFF
--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -139,7 +139,9 @@ public:
 
 private:
   template<typename PT>
-  bool getParamImpl(const std::string & name, const uint8_t type, PT default_value, PT & value_out)
+  bool getParamImpl(
+    const std::string & name, const uint8_t type, PT default_value, PT & value_out,
+    bool read_only)
   {
     std::string param_name = param_prefix_ + name;
 
@@ -149,7 +151,7 @@ private:
       rcl_interfaces::msg::ParameterDescriptor desc;
       desc.name = name;
       desc.type = type;
-      desc.read_only = false;
+      desc.read_only = read_only;
 
       if (name.empty()) {
         throw std::runtime_error("Parameter must have a name");
@@ -177,11 +179,11 @@ protected:
    * \param default_value The default value to use if the parameter is not set
    * \return Whether or not the parameter of name/type was set */
   bool getParam(
-    const std::string & name, std::string & value,
+    const std::string & name, std::string & value, bool read_only = true,
     std::string default_value = std::string())
   {
     return getParamImpl(
-      name, rcl_interfaces::msg::ParameterType::PARAMETER_STRING, default_value, value);
+      name, rcl_interfaces::msg::ParameterType::PARAMETER_STRING, default_value, value, read_only);
   }
 
   /**
@@ -190,11 +192,13 @@ protected:
    * \param value The boolean to set with the value
    * \param default_value The default value to use if the parameter is not set
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string & name, bool & value, bool default_value = false)
+  bool getParam(
+    const std::string & name, bool & value,
+    bool read_only = true, bool default_value = false)
   {
     return getParamImpl(
       name, rcl_interfaces::msg::ParameterType::PARAMETER_BOOL, default_value,
-      value);
+      value, read_only);
   }
 
   /**
@@ -203,11 +207,13 @@ protected:
    * \param value The double to set with the value
    * \param default_value The default value to use if the parameter is not set
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string & name, double & value, double default_value = 0.0)
+  bool getParam(
+    const std::string & name, double & value,
+    bool read_only = true, double default_value = 0.0)
   {
     return getParamImpl(
       name, rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE, default_value,
-      value);
+      value, read_only);
   }
 
   /**
@@ -216,11 +222,13 @@ protected:
    * \param value The int to set with the value
    * \param default_value The default value to use if the parameter is not set
    * \return Whether or not the parameter of name/type was set */
-  bool getParam(const std::string & name, int & value, int default_value = 0)
+  bool getParam(
+    const std::string & name, int & value,
+    bool read_only = true, int default_value = 0)
   {
     return getParamImpl(
       name, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER, default_value,
-      value);
+      value, read_only);
   }
 
   /**
@@ -267,10 +275,12 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(
     const std::string & name, std::vector<double> & value,
+    bool read_only = true,
     std::vector<double> default_value = {})
   {
     return getParamImpl(
-      name, rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY, default_value, value);
+      name, rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY, default_value, value,
+      read_only);
   }
 
   /**
@@ -281,10 +291,12 @@ protected:
    * \return Whether or not the parameter of name/type was set */
   bool getParam(
     const std::string & name, std::vector<std::string> & value,
+    bool read_only = true,
     std::vector<std::string> default_value = {})
   {
     return getParamImpl(
-      name, rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY, default_value, value);
+      name, rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY, default_value, value,
+      read_only);
   }
 
   /// The name of the filter

--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -114,28 +114,29 @@ public:
    */
   virtual bool update(const T & data_in, T & data_out) = 0;
 
-    /**
-   * \brief reconfigureCB 
-   * can be overridden in the derived class
-   * \param parameters A vector parameters to be reconfigured
-   */
-  virtual rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters) 
+  /**
+ * \brief reconfigureCB
+ * can be overridden in the derived class
+ * \param parameters A vector parameters to be reconfigured
+ */
+  virtual rcl_interfaces::msg::SetParametersResult reconfigureCB(
+    std::vector<rclcpp::Parameter> parameters)
   {
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
     return result;
-  };
+  }
 
   /**
    * \brief Get the name of the filter as a string
    */
   inline const std::string & getName() {return filter_name_;}
 
-    /**
-   * \brief Get the parameter_prefix of the filter as a string
-   */
+  /**
+ * \brief Get the parameter_prefix of the filter as a string
+ */
   inline const std::string & getParamPrefix() {return param_prefix_;}
-  
+
 private:
   template<typename PT>
   bool getParamImpl(const std::string & name, const uint8_t type, PT default_value, PT & value_out)

--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -114,11 +114,28 @@ public:
    */
   virtual bool update(const T & data_in, T & data_out) = 0;
 
+    /**
+   * \brief reconfigureCB 
+   * can be overridden in the derived class
+   * \param parameters A vector parameters to be reconfigured
+   */
+  virtual rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters) 
+  {
+    auto result = rcl_interfaces::msg::SetParametersResult();
+    result.successful = true;
+    return result;
+  };
+
   /**
    * \brief Get the name of the filter as a string
    */
   inline const std::string & getName() {return filter_name_;}
 
+    /**
+   * \brief Get the parameter_prefix of the filter as a string
+   */
+  inline const std::string & getParamPrefix() {return param_prefix_;}
+  
 private:
   template<typename PT>
   bool getParamImpl(const std::string & name, const uint8_t type, PT default_value, PT & value_out)
@@ -131,7 +148,7 @@ private:
       rcl_interfaces::msg::ParameterDescriptor desc;
       desc.name = name;
       desc.type = type;
-      desc.read_only = true;
+      desc.read_only = false;
 
       if (name.empty()) {
         throw std::runtime_error("Parameter must have a name");

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -69,7 +69,7 @@ inline bool auto_declare_string(
   rcl_interfaces::msg::ParameterDescriptor param_desc;
   param_desc.name = param_name;
   param_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-  param_desc.read_only = true;
+  param_desc.read_only = false;
   param_desc.dynamic_typing = false;
 
   rclcpp::ParameterValue param_value;
@@ -247,6 +247,8 @@ public:
     }
     logging_interface_ = node_logger;
     params_interface_ = node_params;
+    on_set_parameters_callback_handle_ = params_interface_->add_on_set_parameters_callback(
+              std::bind(&FilterChain<T>::reconfigureCB, this, std::placeholders::_1));
 
     std::vector<struct impl::FoundFilter> found_filters;
     if (!impl::load_chain_config(
@@ -292,6 +294,29 @@ public:
     return true;
   }
 
+  rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters)
+  {
+    auto result = rcl_interfaces::msg::SetParametersResult();
+    result.successful = true;
+
+    for(auto& ref_ptr : reference_pointers_)
+    {
+        std::vector<rclcpp::Parameter> parameters_subset;
+        for(auto parameter : parameters)
+        {
+            if (parameter.get_name().find(ref_ptr->getParamPrefix()) != std::string::npos)
+            {
+                parameters_subset.push_back(parameter);
+            }
+        }
+        if(!parameters_subset.empty() && !ref_ptr->reconfigureCB(parameters_subset).successful)
+        {
+            result.successful = false;
+        }
+    }
+    return result;
+  }
+
 private:
   pluginlib::ClassLoader<filters::FilterBase<T>> loader_;
 
@@ -304,6 +329,7 @@ private:
 
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr params_interface_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr logging_interface_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handle_;
 };
 
 /**
@@ -438,11 +464,36 @@ public:
 
     // Everything went ok!
     reference_pointers_ = std::move(loaded_filters);
+    on_set_parameters_callback_handle_ = params_interface_->add_on_set_parameters_callback(
+      std::bind(&MultiChannelFilterChain<T>::reconfigureCB, this, std::placeholders::_1));
     // Allocate ahead of time
     buffer0_.resize(number_of_channels);
     buffer1_.resize(number_of_channels);
     configured_ = true;
     return true;
+  }
+
+  rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters)
+  {
+    auto result = rcl_interfaces::msg::SetParametersResult();
+    result.successful = true;
+
+    for(auto& ref_ptr : reference_pointers_)
+    {
+        std::vector<rclcpp::Parameter> parameters_subset;
+        for(auto parameter : parameters)
+        {
+            if (parameter.get_name().find(ref_ptr->getParamPrefix()) != std::string::npos)
+            {
+                parameters_subset.push_back(parameter);
+            }
+        }
+        if(!parameters_subset.empty() && !ref_ptr->reconfigureCB(parameters_subset).successful)
+        {
+            result.successful = false;
+        }
+    }
+    return result;
   }
 
 private:
@@ -457,6 +508,7 @@ private:
 
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr params_interface_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr logging_interface_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handle_;
 };
 
 }  // namespace filters

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -69,7 +69,7 @@ inline bool auto_declare_string(
   rcl_interfaces::msg::ParameterDescriptor param_desc;
   param_desc.name = param_name;
   param_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-  param_desc.read_only = false;
+  param_desc.read_only = true;
   param_desc.dynamic_typing = false;
 
   rclcpp::ParameterValue param_value;

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -248,7 +248,7 @@ public:
     logging_interface_ = node_logger;
     params_interface_ = node_params;
     on_set_parameters_callback_handle_ = params_interface_->add_on_set_parameters_callback(
-              std::bind(&FilterChain<T>::reconfigureCB, this, std::placeholders::_1));
+      std::bind(&FilterChain<T>::reconfigureCB, this, std::placeholders::_1));
 
     std::vector<struct impl::FoundFilter> found_filters;
     if (!impl::load_chain_config(
@@ -299,20 +299,16 @@ public:
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
 
-    for(auto& ref_ptr : reference_pointers_)
-    {
-        std::vector<rclcpp::Parameter> parameters_subset;
-        for(auto parameter : parameters)
-        {
-            if (parameter.get_name().find(ref_ptr->getParamPrefix()) != std::string::npos)
-            {
-                parameters_subset.push_back(parameter);
-            }
+    for (auto & ref_ptr : reference_pointers_) {
+      std::vector<rclcpp::Parameter> parameters_subset;
+      for (auto parameter : parameters) {
+        if (parameter.get_name().find(ref_ptr->getParamPrefix()) != std::string::npos) {
+          parameters_subset.push_back(parameter);
         }
-        if(!parameters_subset.empty() && !ref_ptr->reconfigureCB(parameters_subset).successful)
-        {
-            result.successful = false;
-        }
+      }
+      if (!parameters_subset.empty() && !ref_ptr->reconfigureCB(parameters_subset).successful) {
+        result.successful = false;
+      }
     }
     return result;
   }
@@ -329,7 +325,8 @@ private:
 
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr params_interface_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr logging_interface_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handle_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr
+    on_set_parameters_callback_handle_;
 };
 
 /**
@@ -478,20 +475,16 @@ public:
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
 
-    for(auto& ref_ptr : reference_pointers_)
-    {
-        std::vector<rclcpp::Parameter> parameters_subset;
-        for(auto parameter : parameters)
-        {
-            if (parameter.get_name().find(ref_ptr->getParamPrefix()) != std::string::npos)
-            {
-                parameters_subset.push_back(parameter);
-            }
+    for (auto & ref_ptr : reference_pointers_) {
+      std::vector<rclcpp::Parameter> parameters_subset;
+      for (auto parameter : parameters) {
+        if (parameter.get_name().find(ref_ptr->getParamPrefix()) != std::string::npos) {
+          parameters_subset.push_back(parameter);
         }
-        if(!parameters_subset.empty() && !ref_ptr->reconfigureCB(parameters_subset).successful)
-        {
-            result.successful = false;
-        }
+      }
+      if (!parameters_subset.empty() && !ref_ptr->reconfigureCB(parameters_subset).successful) {
+        result.successful = false;
+      }
     }
     return result;
   }
@@ -508,7 +501,8 @@ private:
 
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr params_interface_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr logging_interface_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handle_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr
+    on_set_parameters_callback_handle_;
 };
 
 }  // namespace filters


### PR DESCRIPTION
Hey, 

We wanted to be able to tweak filter parameters dynamically. So we added the functionality to handle parameter updates in the FilterChain. I did have to make parameters readable for that. I don't know if there is a specific reason to make them read_only? 

