### PR TITLE
Ignore unused parameter in FilterBase::reconfigureCB()

### DIFF
--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -122,6 +122,8 @@ public:
   virtual rcl_interfaces::msg::SetParametersResult reconfigureCB(
     std::vector<rclcpp::Parameter> parameters)
   {
+    // Avoid unused parameter warning
+    (void)parameters;
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
     return result;


### PR DESCRIPTION
Follow-up to #83.

`parameters` is unused, which results in a build error/failure when this warning is treated as an error. For example, this package binary build is failing: https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__grid_map_cv__ubuntu_jammy_amd64__binary/55/console