### PR TITLE
Better error handling when loading chains

### DIFF
--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -31,6 +31,7 @@
 #define FILTERS__FILTER_CHAIN_HPP_
 
 #include <algorithm>
+#include <cstddef>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -294,6 +295,14 @@ public:
     return true;
   }
 
+  /**
+   * \brief Get the length of the chain (number of configured filters)
+   */
+  size_t get_length()
+  {
+    return reference_pointers_.size();
+  }
+
   rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters)
   {
     auto result = rcl_interfaces::msg::SetParametersResult();
@@ -468,6 +477,14 @@ public:
     buffer1_.resize(number_of_channels);
     configured_ = true;
     return true;
+  }
+
+  /**
+   * \brief Get the length of the chain (number of configured filters)
+   */
+  size_t get_length()
+  {
+    return reference_pointers_.size();
   }
 
   rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters)

--- a/include/filters/filter_chain.hpp
+++ b/include/filters/filter_chain.hpp
@@ -191,6 +191,9 @@ public:
    */
   bool update(const T & data_in, T & data_out)
   {
+    if (!configured_) {
+      throw std::runtime_error("The update cannot be called without configuring the filter chain!");
+    }
     bool result;
     size_t list_size = reference_pointers_.size();
     if (list_size == 0) {
@@ -361,6 +364,9 @@ public:
    */
   bool update(const std::vector<T> & data_in, std::vector<T> & data_out)
   {
+    if (!configured_) {
+      throw std::runtime_error("The update cannot be called without configuring the filter chain!");
+    }
     bool result;
     size_t list_size = reference_pointers_.size();
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -438,3 +438,97 @@ TEST_F(ChainTest, TenMultiChannelIncrementChains) {
     EXPECT_EQ(11, v1a[i]);
   }
 }
+
+TEST_F(ChainTest, TestChainLength) {
+  filters::FilterChain<int> chain("int");
+
+  std::vector<rclcpp::Parameter> overrides;
+  overrides.emplace_back("OneIncrements.filter1.name", std::string("increment1"));
+  overrides.emplace_back("OneIncrements.filter1.type", std::string("filters/IncrementFilterInt"));
+
+  overrides.emplace_back("TwoIncrements.filter1.name", std::string("increment1"));
+  overrides.emplace_back("TwoIncrements.filter1.type", std::string("filters/IncrementFilterInt"));
+  overrides.emplace_back("TwoIncrements.filter2.name", std::string("increment2"));
+  overrides.emplace_back("TwoIncrements.filter2.type", std::string("filters/IncrementFilterInt"));
+
+  overrides.emplace_back("FiveIncrements.filter1.name", std::string("increment1"));
+  overrides.emplace_back("FiveIncrements.filter1.type", std::string("filters/IncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter2.name", std::string("increment2"));
+  overrides.emplace_back("FiveIncrements.filter2.type", std::string("filters/IncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter3.name", std::string("increment3"));
+  overrides.emplace_back("FiveIncrements.filter3.type", std::string("filters/IncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter4.name", std::string("increment4"));
+  overrides.emplace_back("FiveIncrements.filter4.type", std::string("filters/IncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter5.name", std::string("increment5"));
+  overrides.emplace_back("FiveIncrements.filter5.type", std::string("filters/IncrementFilterInt"));
+  auto node = make_node_with_params(overrides);
+
+  ASSERT_TRUE(
+    chain.configure(
+      "ZeroFilters", node->get_node_logging_interface(), node->get_node_parameters_interface()));
+  EXPECT_EQ(chain.get_length(), 0);
+  chain.clear();
+
+  ASSERT_TRUE(
+    chain.configure(
+      "TwoIncrements", node->get_node_logging_interface(), node->get_node_parameters_interface()));
+  EXPECT_EQ(chain.get_length(), 2);
+  chain.clear();
+
+  ASSERT_TRUE(
+    chain.configure(
+      "FiveIncrements", node->get_node_logging_interface(), node->get_node_parameters_interface()));
+  EXPECT_EQ(chain.get_length(), 5);
+}
+
+TEST_F(ChainTest, TestMultiChannelChainLength) {
+  filters::MultiChannelFilterChain<int> chain("int");
+
+  std::vector<rclcpp::Parameter> overrides;
+  overrides.emplace_back("OneIncrements.filter1.name", std::string("increment1"));
+  overrides.emplace_back(
+    "OneIncrements.filter1.type", std::string("filters/MultiChannelIncrementFilterInt"));
+
+  overrides.emplace_back("TwoIncrements.filter1.name", std::string("increment1"));
+  overrides.emplace_back(
+    "TwoIncrements.filter1.type", std::string("filters/MultiChannelIncrementFilterInt"));
+  overrides.emplace_back("TwoIncrements.filter2.name", std::string("increment2"));
+  overrides.emplace_back(
+    "TwoIncrements.filter2.type", std::string("filters/MultiChannelIncrementFilterInt"));
+
+  overrides.emplace_back("FiveIncrements.filter1.name", std::string("increment1"));
+  overrides.emplace_back(
+    "FiveIncrements.filter1.type", std::string("filters/MultiChannelIncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter2.name", std::string("increment2"));
+  overrides.emplace_back(
+    "FiveIncrements.filter2.type", std::string("filters/MultiChannelIncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter3.name", std::string("increment3"));
+  overrides.emplace_back(
+    "FiveIncrements.filter3.type", std::string("filters/MultiChannelIncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter4.name", std::string("increment4"));
+  overrides.emplace_back(
+    "FiveIncrements.filter4.type", std::string("filters/MultiChannelIncrementFilterInt"));
+  overrides.emplace_back("FiveIncrements.filter5.name", std::string("increment5"));
+  overrides.emplace_back(
+    "FiveIncrements.filter5.type", std::string("filters/MultiChannelIncrementFilterInt"));
+  auto node = make_node_with_params(overrides);
+
+  ASSERT_TRUE(
+    chain.configure(
+      3, "ZeroFilters", node->get_node_logging_interface(), node->get_node_parameters_interface()));
+  EXPECT_EQ(chain.get_length(), 0);
+  chain.clear();
+
+  ASSERT_TRUE(
+    chain.configure(
+      3, "TwoIncrements", node->get_node_logging_interface(),
+      node->get_node_parameters_interface()));
+  EXPECT_EQ(chain.get_length(), 2);
+  chain.clear();
+
+  ASSERT_TRUE(
+    chain.configure(
+      3, "FiveIncrements", node->get_node_logging_interface(),
+      node->get_node_parameters_interface()));
+  EXPECT_EQ(chain.get_length(), 5);
+}


### PR DESCRIPTION
As described in https://github.com/ros/filters/issues/89, loading a sensor chain without configuration would succeed, making it impossible to know from the calling code if there's actually a working filter chain.

The fix is trivial: just consider a chain configured if the resulting `found_filters` vector after loading the configuration is not empty.

I also added a check in the `update` function to throw if someone tries to call update without configuring the chain first.