### PR TITLE
fix getParam to return value

### DIFF
--- a/include/filters/filter_base.hpp
+++ b/include/filters/filter_base.hpp
@@ -149,21 +149,21 @@ private:
 
     if (!params_interface_->has_parameter(param_name)) {
       // Declare parameter
-      rclcpp::ParameterValue default_parameter_value(default_value);
+      if (name.empty()) {
+        throw std::runtime_error("Parameter must have a name");
+      }
       rcl_interfaces::msg::ParameterDescriptor desc;
       desc.name = name;
       desc.type = type;
       desc.read_only = read_only;
-
-      if (name.empty()) {
-        throw std::runtime_error("Parameter must have a name");
-      }
-
-      params_interface_->declare_parameter(param_name, default_parameter_value, desc);
+      params_interface_->declare_parameter(param_name, rclcpp::ParameterType(type), desc);
     }
-
-    value_out = params_interface_->get_parameter(param_name).get_parameter_value().get<PT>();
-    // TODO(sloretz) seems to be no way to tell if parameter was initialized or not
+    rclcpp::Parameter param_value;
+    if (!params_interface_->get_parameter(param_name, param_value)) {
+      value_out = default_value;
+      return false;
+    }
+    value_out = param_value.get_parameter_value().get<PT>();
     return true;
   }
 


### PR DESCRIPTION
This fixes getParam return value to be false if the parameter is not set.

getParam should return false according to the documentation. This was previously the behavior in ros1, but seems to be broken for ros2.

fixes https://github.com/ros/filters/issues/92